### PR TITLE
Fixed product number of the relay

### DIFF
--- a/KiCad/LaserBackplane_DVI.kicad_pcb
+++ b/KiCad/LaserBackplane_DVI.kicad_pcb
@@ -983,7 +983,7 @@
 				)
 			)
 		)
-		(property "PN" "G6AU-274P-ST-US-DC9"
+		(property "PN" "G6AU-274P-ST-US DC9"
 			(at 0 0 270)
 			(layer "F.Fab")
 			(hide yes)
@@ -10382,7 +10382,7 @@
 			)
 		)
 		(property ki_fp_filters "MSOP*3x3mm*P0.65mm*")
-		(path "/00000000-0000-0000-0000-0000607b7d1b")
+		(path "/00000000-0000-0000-0000-000060709020")
 		(sheetname "/")
 		(sheetfile "LaserBackplane_DVI.kicad_sch")
 		(attr smd)
@@ -17855,7 +17855,7 @@
 			(drill 3)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(net 20 "unconnected-(J2-PadSH)")
+			(net 49 "unconnected-(J2-PadSH)_1")
 			(pinfunction "SH")
 			(pintype "passive+no_connect")
 			(teardrops
@@ -17877,7 +17877,7 @@
 			(drill 3)
 			(layers "*.Cu" "*.Mask")
 			(remove_unused_layers no)
-			(net 49 "unconnected-(J2-PadSH)_1")
+			(net 20 "unconnected-(J2-PadSH)")
 			(pinfunction "SH")
 			(pintype "passive+no_connect")
 			(teardrops
@@ -22794,13 +22794,13 @@
 		)
 	)
 	(zone
-		(net 14)
-		(net_name "Relay-")
+		(net 21)
+		(net_name "Net-(J2-DDCIO)")
 		(layer "F.Cu")
-		(uuid "002a1279-dc53-4c21-969d-6c5cc9109a6c")
+		(uuid "01234a48-45bd-40ca-b93b-2e112874db12")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30120)
+		(priority 30075)
 		(attr
 			(teardrop
 				(type padvia)
@@ -22819,17 +22819,56 @@
 		)
 		(polygon
 			(pts
-				(xy 116.95 94.175) (xy 116.95 93.925) (xy 116.71754 93.825) (xy 116.499 94.05) (xy 116.71754 94.275)
+				(xy 112.55 101.275) (xy 112.35 101.275) (xy 112.161418 101.667597) (xy 112.45 102.3135) (xy 112.738582 101.667597)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 116.724941 93.828184) (xy 116.730976 93.83078) (xy 116.942924 93.921956) (xy 116.949169 93.928372)
-				(xy 116.95 93.932703) (xy 116.95 94.167296) (xy 116.946573 94.175569) (xy 116.942923 94.178044)
-				(xy 116.724941 94.271815) (xy 116.715987 94.271936) (xy 116.711925 94.269219) (xy 116.707463 94.264625)
-				(xy 116.506916 94.05815) (xy 116.503611 94.04983) (xy 116.506916 94.041849) (xy 116.711926 93.830779)
-				(xy 116.720148 93.827233)
+				(xy 112.550914 101.278427) (xy 112.553187 101.281634) (xy 112.736234 101.662708) (xy 112.736728 101.671649)
+				(xy 112.73637 101.672547) (xy 112.460682 102.289591) (xy 112.454179 102.295746) (xy 112.445227 102.2955)
+				(xy 112.439318 102.289591) (xy 112.355123 102.101148) (xy 112.163628 101.672545) (xy 112.163383 101.663595)
+				(xy 112.163752 101.662736) (xy 112.346813 101.281633) (xy 112.353484 101.27566) (xy 112.357359 101.275)
+				(xy 112.542641 101.275)
+			)
+		)
+	)
+	(zone
+		(net 31)
+		(net_name "V_diode-")
+		(layer "F.Cu")
+		(uuid "021b003b-5f8f-4fc3-9be1-f2988783e81b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30067)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 118.925 103.625) (xy 118.725 103.625) (xy 118.440224 104.148463) (xy 118.825 104.501) (xy 119.209776 104.148463)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 118.926318 103.628427) (xy 118.928323 103.631109) (xy 119.205403 104.140426) (xy 119.206346 104.149331)
+				(xy 119.203029 104.154644) (xy 118.832904 104.493758) (xy 118.824489 104.49682) (xy 118.817096 104.493758)
+				(xy 118.44697 104.154644) (xy 118.443185 104.146528) (xy 118.444596 104.140426) (xy 118.721677 103.631109)
+				(xy 118.728641 103.625479) (xy 118.731955 103.625) (xy 118.918045 103.625)
 			)
 		)
 	)
@@ -22837,10 +22876,10 @@
 		(net 6)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "007b5287-3943-4d52-8c9c-57e0bdb021f4")
+		(uuid "03ff4e4c-b8a5-4724-a68b-89e8fdf404fc")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30077)
+		(priority 30078)
 		(attr
 			(teardrop
 				(type padvia)
@@ -22859,24 +22898,24 @@
 		)
 		(polygon
 			(pts
-				(xy 144.705764 103.25) (xy 144.705764 103.75) (xy 145.241473 103.794236) (xy 145.301 103.5) (xy 145.241473 103.205764)
+				(xy 132.505764 93.45) (xy 132.505764 93.95) (xy 133.041473 93.994236) (xy 133.101 93.7) (xy 133.041473 93.405764)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 145.301 103.5) (xy 145.241473 103.794236) (xy 144.705764 103.75) (xy 144.705764 103.25) (xy 145.241473 103.205764)
+				(xy 133.101 93.7) (xy 133.041473 93.994236) (xy 132.505764 93.95) (xy 132.505764 93.45) (xy 133.041473 93.405764)
 			)
 		)
 	)
 	(zone
-		(net 10)
-		(net_name "Net-(U3-BYP)")
+		(net 6)
+		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "01da59b9-ad04-4af2-a698-8fd062aad130")
+		(uuid "05dab971-bb44-4c02-ba79-d477b4ea1776")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30046)
+		(priority 30073)
 		(attr
 			(teardrop
 				(type padvia)
@@ -22895,29 +22934,27 @@
 		)
 		(polygon
 			(pts
-				(xy 141.484099 105.992677) (xy 141.307323 105.815901) (xy 140.836104 105.542127) (xy 140.499293 105.975707)
-				(xy 140.848972 106.399274)
+				(xy 111.625 103.15) (xy 111.375 103.15) (xy 111.211418 103.542597) (xy 111.5 104.1885) (xy 111.788582 103.542597)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 140.844947 105.547265) (xy 140.850006 105.550204) (xy 141.306009 105.815137) (xy 141.308402 105.81698)
-				(xy 141.473814 105.982392) (xy 141.477241 105.990665) (xy 141.473814 105.998938) (xy 141.471849 106.000519)
-				(xy 140.857703 106.393684) (xy 140.848888 106.395258) (xy 140.842372 106.391279) (xy 140.70408 106.223766)
-				(xy 140.505257 105.982932) (xy 140.502634 105.974371) (xy 140.505039 105.968309) (xy 140.82983 105.550203)
-				(xy 140.837611 105.545773)
+				(xy 111.625473 103.153427) (xy 111.628 103.1572) (xy 111.786639 103.537935) (xy 111.786658 103.54689)
+				(xy 111.786521 103.547208) (xy 111.510682 104.164591) (xy 111.504179 104.170746) (xy 111.495227 104.1705)
+				(xy 111.489318 104.164591) (xy 111.213478 103.547208) (xy 111.213232 103.538256) (xy 111.21336 103.537935)
+				(xy 111.372 103.1572) (xy 111.378345 103.150881) (xy 111.3828 103.15) (xy 111.6172 103.15)
 			)
 		)
 	)
 	(zone
-		(net 8)
-		(net_name "Net-(U1A-+)")
+		(net 1)
+		(net_name "Net-(C3-Pad2)")
 		(layer "F.Cu")
-		(uuid "06574db9-9f6c-4364-8977-d0c59a075707")
+		(uuid "0885c2cc-9843-4874-a9cf-1703fc87e947")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30101)
+		(priority 30009)
 		(attr
 			(teardrop
 				(type padvia)
@@ -22936,16 +22973,448 @@
 		)
 		(polygon
 			(pts
-				(xy 136.45 116.875) (xy 136.7 116.875) (xy 136.767388 116.613268) (xy 136.575 115.8615) (xy 136.382612 116.613268)
+				(xy 94.75 104.584628) (xy 95.25 104.584628) (xy 95.784628 103.156072) (xy 95 102.999) (xy 94.215372 103.156072)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 136.585066 115.902729) (xy 136.586335 115.905792) (xy 136.766643 116.610359) (xy 136.766638 116.616177)
-				(xy 136.702261 116.866217) (xy 136.69688 116.873375) (xy 136.690931 116.875) (xy 136.459069 116.875)
-				(xy 136.450796 116.871573) (xy 136.447739 116.866217) (xy 136.383361 116.616177) (xy 136.383356 116.610359)
-				(xy 136.563665 115.905792) (xy 136.569036 115.898627) (xy 136.577901 115.897358)
+				(xy 95.771149 103.153373) (xy 95.778587 103.158357) (xy 95.780323 103.167142) (xy 95.779809 103.168946)
+				(xy 95.252844 104.577029) (xy 95.246735 104.583576) (xy 95.241886 104.584628) (xy 94.758114 104.584628)
+				(xy 94.749841 104.581201) (xy 94.747156 104.577029) (xy 94.22019 103.168946) (xy 94.2205 103.159996)
+				(xy 94.227047 103.153887) (xy 94.228842 103.153375) (xy 94.997707 102.999459) (xy 95.002293 102.999459)
+			)
+		)
+	)
+	(zone
+		(net 4)
+		(net_name "LD_short-")
+		(layer "F.Cu")
+		(uuid "09abadb5-94d0-4501-bbd5-500e000468e0")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30061)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 117.05 105.375) (xy 117.3 105.375) (xy 117.559776 104.851537) (xy 117.175 104.499) (xy 116.790224 104.851537)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 117.182902 104.50624) (xy 117.445197 104.746558) (xy 117.553287 104.845592) (xy 117.557072 104.853708)
+				(xy 117.555863 104.85942) (xy 117.303225 105.368501) (xy 117.296478 105.374388) (xy 117.292745 105.375)
+				(xy 117.057255 105.375) (xy 117.048982 105.371573) (xy 117.046775 105.368501) (xy 116.794136 104.85942)
+				(xy 116.793528 104.850486) (xy 116.796711 104.845593) (xy 117.167097 104.50624) (xy 117.175511 104.503179)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "0ec87938-339e-4c12-9a01-f981fae6ba2b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30028)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 94.85 94.45) (xy 94.35 94.45) (xy 94.167127 95.038896) (xy 94.6 95.501) (xy 95.032873 95.038896)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 94.849655 94.453427) (xy 94.852556 94.45823) (xy 95.030854 95.032395) (xy 95.030034 95.041312)
+				(xy 95.028219 95.043864) (xy 94.608539 95.491884) (xy 94.600382 95.495579) (xy 94.592001 95.492424)
+				(xy 94.591461 95.491884) (xy 94.455628 95.346879) (xy 94.171779 95.043862) (xy 94.168625 95.035483)
+				(xy 94.169144 95.0324) (xy 94.347444 94.458229) (xy 94.353171 94.451346) (xy 94.358618 94.45) (xy 94.841382 94.45)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "1349da44-23af-43d0-9828-e5b567381a11")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30029)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 94.35 96.55) (xy 94.85 96.55) (xy 95.032873 95.961104) (xy 94.6 95.499) (xy 94.167127 95.961104)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 94.607999 95.507575) (xy 94.608529 95.508105) (xy 95.028219 95.956136) (xy 95.031374 95.964516)
+				(xy 95.030854 95.967604) (xy 94.852556 96.54177) (xy 94.846829 96.548654) (xy 94.841382 96.55) (xy 94.358618 96.55)
+				(xy 94.350345 96.546573) (xy 94.347444 96.54177) (xy 94.169145 95.967604) (xy 94.169965 95.958687)
+				(xy 94.171774 95.956142) (xy 94.591462 95.508114) (xy 94.599618 95.50442)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "13978609-c851-4ba3-bdaf-510cef11be04")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30110)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 110.1 94.0625) (xy 110.1 93.8125) (xy 109.8 93.6375) (xy 109.499 93.9375) (xy 109.8 94.2375)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 109.807775 93.642035) (xy 110.094196 93.809114) (xy 110.099615 93.816241) (xy 110.1 93.819219)
+				(xy 110.1 94.05578) (xy 110.096573 94.064053) (xy 110.094195 94.065886) (xy 109.807777 94.232963)
+				(xy 109.798904 94.234172) (xy 109.793623 94.231144) (xy 109.625975 94.064053) (xy 109.507313 93.945785)
+				(xy 109.503873 93.937519) (xy 109.507285 93.929241) (xy 109.793624 93.643854) (xy 109.801901 93.640442)
+			)
+		)
+	)
+	(zone
+		(net 44)
+		(net_name "Net-(RN1A-R1.2)")
+		(layer "F.Cu")
+		(uuid "14254e36-51f6-492e-aafb-5d642d9928fc")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30068)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 130.251257 108.771967) (xy 130.428033 108.948743) (xy 130.848463 109.209776) (xy 131.200707 108.824293)
+				(xy 130.848463 108.440224)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 130.8547 108.447025) (xy 131.193467 108.816399) (xy 131.196533 108.824812) (xy 131.193481 108.832199)
+				(xy 130.855017 109.202603) (xy 130.846907 109.206399) (xy 130.840209 109.204651) (xy 130.42918 108.949455)
+				(xy 130.427078 108.947788) (xy 130.262225 108.782935) (xy 130.258798 108.774662) (xy 130.262225 108.766389)
+				(xy 130.26481 108.764438) (xy 130.840396 108.444704) (xy 130.849292 108.443683)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "18db8f4e-a735-4e74-84dd-a803aeffc7c5")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30041)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 98.8 95.625) (xy 98.8 95.375) (xy 98.335082 95.05) (xy 97.899 95.5) (xy 98.335082 95.95)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 98.34325 95.05571) (xy 98.795003 95.371507) (xy 98.799821 95.379054) (xy 98.8 95.381095) (xy 98.8 95.618904)
+				(xy 98.796573 95.627177) (xy 98.795003 95.628493) (xy 98.34325 95.944289) (xy 98.334506 95.946221)
+				(xy 98.328145 95.942842) (xy 98.022243 95.627177) (xy 97.906889 95.508141) (xy 97.903593 95.499816)
+				(xy 97.90689 95.491858) (xy 98.016205 95.379054) (xy 98.328147 95.057155) (xy 98.336363 95.0536)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "19f85c95-9d49-434d-838b-ee1f3b423a1e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30025)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 140.525 91.675) (xy 140.525 91.925) (xy 141.179329 92.28097) (xy 141.751 91.8) (xy 141.179329 91.31903)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 141.185438 91.32417) (xy 141.740358 91.791047) (xy 141.744483 91.798996) (xy 141.741779 91.807532)
+				(xy 141.740358 91.808953) (xy 141.185438 92.275829) (xy 141.176902 92.278533) (xy 141.172315 92.277154)
+				(xy 140.531109 91.928323) (xy 140.525479 91.921359) (xy 140.525 91.918045) (xy 140.525 91.681954)
+				(xy 140.528427 91.673681) (xy 140.531106 91.671678) (xy 141.172316 91.322844) (xy 141.18122 91.321902)
+			)
+		)
+	)
+	(zone
+		(net 13)
+		(net_name "Net-(J1-In)")
+		(layer "F.Cu")
+		(uuid "1ce1edf6-f455-4fed-9289-aea2c259876c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30005)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 149.494695 112.25) (xy 149.494695 112.75) (xy 150.930541 113.352256) (xy 151.501 112.5) (xy 150.930541 111.647744)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 150.935901 111.655753) (xy 151.496643 112.493492) (xy 151.498397 112.502273) (xy 151.496643 112.506508)
+				(xy 150.935901 113.344246) (xy 150.928451 113.349215) (xy 150.921652 113.348527) (xy 149.501869 112.753009)
+				(xy 149.495566 112.746649) (xy 149.494695 112.74222) (xy 149.494695 112.257779) (xy 149.498122 112.249506)
+				(xy 149.501865 112.246992) (xy 150.921653 111.651471) (xy 150.930607 111.651432)
+			)
+		)
+	)
+	(zone
+		(net 7)
+		(net_name "Net-(RN1B-R2.2)")
+		(layer "F.Cu")
+		(uuid "1d3f5829-2921-449c-801d-51e2e8258f08")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30107)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 136.675 110.625) (xy 136.475 110.625) (xy 136.382612 110.886732) (xy 136.575 111.6385) (xy 136.767388 110.886732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 136.674995 110.628427) (xy 136.677755 110.632806) (xy 136.766204 110.88338) (xy 136.766506 110.890175)
+				(xy 136.586335 111.594207) (xy 136.580964 111.601372) (xy 136.572099 111.602641) (xy 136.564934 111.59727)
+				(xy 136.563665 111.594207) (xy 136.383493 110.890175) (xy 136.383795 110.88338) (xy 136.472245 110.632806)
+				(xy 136.47823 110.626145) (xy 136.483278 110.625) (xy 136.666722 110.625)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "24a8a8a7-e161-4e7e-b108-16ae31dd2405")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30036)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 134.381586 112.695191) (xy 134.204809 112.518414) (xy 133.389192 112.575) (xy 133.499293 113.025707)
+				(xy 133.967554 113.287429)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 134.207984 112.521628) (xy 134.208576 112.522181) (xy 134.374649 112.688254) (xy 134.378076 112.696527)
+				(xy 134.375965 112.703231) (xy 133.973615 113.278758) (xy 133.966066 113.283575) (xy 133.958318 113.282267)
+				(xy 133.503741 113.028193) (xy 133.498191 113.021165) (xy 133.49809 113.020783) (xy 133.392486 112.588485)
+				(xy 133.393852 112.579637) (xy 133.401076 112.574345) (xy 133.40304 112.574039) (xy 134.199495 112.518782)
+			)
+		)
+	)
+	(zone
+		(net 36)
+		(net_name "-5V")
+		(layer "F.Cu")
+		(uuid "26c96620-ca91-4b0d-a0c9-fdc1f37a1578")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30030)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 144.376777 108.723224) (xy 144.023224 109.076777) (xy 143.823223 109.348223) (xy 144.250707 110.000707)
+				(xy 144.724467 109.419596)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 144.381837 108.734709) (xy 144.384032 108.737756) (xy 144.721091 109.412834) (xy 144.72172 109.421766)
+				(xy 144.719691 109.425453) (xy 144.260804 109.988321) (xy 144.252921 109.992568) (xy 144.244343 109.989996)
+				(xy 144.241949 109.98734) (xy 143.82768 109.355026) (xy 143.826013 109.346228) (xy 143.828048 109.341674)
+				(xy 144.022706 109.077479) (xy 144.023839 109.076161) (xy 144.365292 108.734708) (xy 144.373564 108.731282)
 			)
 		)
 	)
@@ -22953,7 +23422,7 @@
 		(net 11)
 		(net_name "Net-(D2-A)")
 		(layer "F.Cu")
-		(uuid "075dd957-d9b0-47f2-afc1-3cf1eee833dd")
+		(uuid "2a7b97fa-3c3a-4ef5-a385-ff2941cee3c8")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30121)
@@ -22989,13 +23458,13 @@
 		)
 	)
 	(zone
-		(net 6)
-		(net_name "GND")
+		(net 3)
+		(net_name "Net-(J2-DDCCL)")
 		(layer "F.Cu")
-		(uuid "0adcb7f5-b506-49c4-a4c6-6031cec3d04d")
+		(uuid "2ac9305d-2287-440f-a00c-8fc6edf88c67")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30093)
+		(priority 30016)
 		(attr
 			(teardrop
 				(type padvia)
@@ -23014,16 +23483,295 @@
 		)
 		(polygon
 			(pts
-				(xy 130.3 115.219236) (xy 130.55 115.219236) (xy 130.719236 114.683527) (xy 130.425 114.624) (xy 130.130764 114.683527)
+				(xy 123.672981 96.596205) (xy 123.496205 96.772981) (xy 123.85749 97.721809) (xy 124.495707 97.595707)
+				(xy 124.621809 96.95749)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 130.706479 114.680946) (xy 130.713907 114.685945) (xy 130.715626 114.694733) (xy 130.715315 114.695937)
-				(xy 130.552583 115.21106) (xy 130.546823 115.217917) (xy 130.541426 115.219236) (xy 130.308574 115.219236)
-				(xy 130.300301 115.215809) (xy 130.297417 115.21106) (xy 130.134684 114.695937) (xy 130.13546 114.687016)
-				(xy 130.142317 114.681256) (xy 130.1435 114.68095) (xy 130.422682 114.624469) (xy 130.427318 114.624469)
+				(xy 123.680057 96.598899) (xy 124.612579 96.953975) (xy 124.619092 96.960121) (xy 124.619894 96.967177)
+				(xy 124.497226 97.588016) (xy 124.492261 97.595468) (xy 124.488016 97.597226) (xy 123.867177 97.719894)
+				(xy 123.858396 97.718136) (xy 123.853975 97.712579) (xy 123.810052 97.597226) (xy 123.4989 96.780058)
+				(xy 123.499158 96.771109) (xy 123.501558 96.767627) (xy 123.667625 96.60156) (xy 123.675897 96.598134)
+			)
+		)
+	)
+	(zone
+		(net 36)
+		(net_name "-5V")
+		(layer "F.Cu")
+		(uuid "2b7adfdc-d732-4a5d-b68d-4f106e405b2e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30065)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 139.92552 115.651257) (xy 139.748743 115.47448) (xy 139.336104 115.342127) (xy 138.999293 115.775707)
+				(xy 139.427772 116.131152)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 139.343894 115.344625) (xy 139.746047 115.473615) (xy 139.750745 115.476482) (xy 139.917094 115.642831)
+				(xy 139.920521 115.651104) (xy 139.917094 115.659377) (xy 139.916942 115.659527) (xy 139.435307 116.123887)
+				(xy 139.426972 116.127162) (xy 139.419716 116.124469) (xy 139.008014 115.782941) (xy 139.003834 115.775021)
+				(xy 139.006243 115.766759) (xy 139.331085 115.348587) (xy 139.338865 115.344158)
+			)
+		)
+	)
+	(zone
+		(net 44)
+		(net_name "Net-(RN1A-R1.2)")
+		(layer "F.Cu")
+		(uuid "2c8236f6-8f80-419e-ac63-ca2a964d2bcb")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30103)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 131.2 114.85) (xy 130.95 114.85) (xy 130.882612 115.111732) (xy 131.075 115.8635) (xy 131.267388 115.111732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.199204 114.853427) (xy 131.202261 114.858783) (xy 131.266638 115.108822) (xy 131.266643 115.11464)
+				(xy 131.086335 115.819207) (xy 131.080964 115.826372) (xy 131.072099 115.827641) (xy 131.064934 115.82227)
+				(xy 131.063665 115.819207) (xy 130.883356 115.11464) (xy 130.883361 115.108822) (xy 130.947739 114.858783)
+				(xy 130.95312 114.851625) (xy 130.959069 114.85) (xy 131.190931 114.85)
+			)
+		)
+	)
+	(zone
+		(net 8)
+		(net_name "Net-(U1A-+)")
+		(layer "F.Cu")
+		(uuid "2dced3ad-83ed-46f3-bb16-3a29c7793ccf")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30069)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 141.625 115.625) (xy 141.625 115.875) (xy 142.072607 116.15) (xy 142.426 115.75) (xy 142.072607 115.35)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 142.079119 115.357371) (xy 142.419155 115.742253) (xy 142.422065 115.750722) (xy 142.419155 115.757747)
+				(xy 142.079119 116.142628) (xy 142.071073 116.146559) (xy 142.064226 116.14485) (xy 141.630575 115.878425)
+				(xy 141.62532 115.871174) (xy 141.625 115.868456) (xy 141.625 115.631543) (xy 141.628427 115.62327)
+				(xy 141.63057 115.621577) (xy 142.064226 115.355148) (xy 142.073069 115.353738)
+			)
+		)
+	)
+	(zone
+		(net 4)
+		(net_name "LD_short-")
+		(layer "F.Cu")
+		(uuid "2ed93aa3-4ada-4e8f-9c1a-b6b5fd68971a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30002)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 101.062584 116.669691) (xy 101.769691 115.962584) (xy 101.200785 114.55491) (xy 100.219293 114.749293)
+				(xy 99.66443 115.58147)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 101.200071 114.558544) (xy 101.204411 114.563883) (xy 101.766789 115.955403) (xy 101.766711 115.964357)
+				(xy 101.764214 115.96806) (xy 101.069889 116.662385) (xy 101.061616 116.665812) (xy 101.054431 116.663345)
+				(xy 99.67301 115.588148) (xy 99.668586 115.580362) (xy 99.67046 115.572425) (xy 100.216599 114.753333)
+				(xy 100.224036 114.748353) (xy 101.191291 114.55679)
+			)
+		)
+	)
+	(zone
+		(net 21)
+		(net_name "Net-(J2-DDCIO)")
+		(layer "F.Cu")
+		(uuid "317c58a0-27ea-49ee-a4bf-8f27a7034848")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30020)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 121.608882 98.434696) (xy 121.750304 98.576118) (xy 122.716809 98.23251) (xy 122.590707 97.594293)
+				(xy 121.95249 97.468191)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 122.583016 97.592773) (xy 122.590468 97.597738) (xy 122.592226 97.601983) (xy 122.714851 98.222601)
+				(xy 122.713093 98.231382) (xy 122.707292 98.235893) (xy 121.757268 98.573641) (xy 121.748325 98.573183)
+				(xy 121.745076 98.57089) (xy 121.614109 98.439923) (xy 121.610682 98.43165) (xy 121.611358 98.427731)
+				(xy 121.949107 97.477705) (xy 121.955106 97.47106) (xy 121.962395 97.470148)
+			)
+		)
+	)
+	(zone
+		(net 54)
+		(net_name "Net-(RN1C-R3.2)")
+		(layer "F.Cu")
+		(uuid "34fd00bd-7a30-4cad-9abb-63afb51f0201")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30117)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 135.925 110.583579) (xy 135.783579 110.725) (xy 135.732612 110.886732) (xy 135.925707 111.638207)
+				(xy 136.067988 110.835765)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 135.930676 110.594448) (xy 135.932581 110.59695) (xy 136.06591 110.8321) (xy 136.067252 110.839914)
+				(xy 135.935128 111.58507) (xy 135.93031 111.592617) (xy 135.921565 111.594547) (xy 135.914018 111.589729)
+				(xy 135.912276 111.585939) (xy 135.733444 110.88997) (xy 135.733616 110.883543) (xy 135.782719 110.727727)
+				(xy 135.785602 110.722976) (xy 135.914131 110.594447) (xy 135.922403 110.591021)
+			)
+		)
+	)
+	(zone
+		(net 42)
+		(net_name "Net-(J5-Pin_1)")
+		(layer "F.Cu")
+		(uuid "35023ffa-45cc-419f-8a90-6b40ddd5b401")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30004)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 151.109619 94.713172) (xy 151.463172 94.359619) (xy 151.45 93.427208) (xy 149.749293 92.999293)
+				(xy 149.377208 93.9)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 151.441282 93.425014) (xy 151.448469 93.430356) (xy 151.450126 93.436195) (xy 151.463102 94.354676)
+				(xy 151.459792 94.362996) (xy 151.459676 94.363114) (xy 151.115427 94.707363) (xy 151.107154 94.71079)
+				(xy 151.102183 94.709681) (xy 149.387312 93.904742) (xy 149.381279 93.898125) (xy 149.381468 93.889685)
+				(xy 149.745432 93.008637) (xy 149.751757 93.002301) (xy 149.759098 93.00176)
 			)
 		)
 	)
@@ -23031,7 +23779,1553 @@
 		(net 46)
 		(net_name "Net-(RN1A-R1.1)")
 		(layer "F.Cu")
-		(uuid "0b054488-b45e-4714-b92b-07ade596dfd6")
+		(uuid "35981288-d0fa-4142-a46f-07b0dd52c86d")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30115)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 129.757323 116.934099) (xy 129.934099 116.757323) (xy 129.967388 116.613268) (xy 129.774293 115.861793)
+				(xy 129.632012 116.664234)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 129.785981 115.91027) (xy 129.787723 115.91406) (xy 129.966677 116.610502) (xy 129.966745 116.616048)
+				(xy 129.934853 116.754056) (xy 129.931726 116.759695) (xy 129.769158 116.922263) (xy 129.760885 116.92569)
+				(xy 129.752612 116.922263) (xy 129.750275 116.918921) (xy 129.633562 116.667573) (xy 129.632655 116.660606)
+				(xy 129.764871 115.914928) (xy 129.769689 115.907382) (xy 129.778434 115.905452)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "35b620b0-e546-4ff0-9fa8-4dd469182cd2")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30076)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 138.35 92.175) (xy 138.35 91.925) (xy 137.957403 91.761418) (xy 137.3865 92.05) (xy 137.957403 92.338582)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 137.962368 91.763486) (xy 137.963233 91.763847) (xy 138.3428 91.922) (xy 138.349119 91.928345)
+				(xy 138.35 91.9328) (xy 138.35 92.167199) (xy 138.346573 92.175472) (xy 138.3428 92.177999) (xy 137.962374 92.33651)
+				(xy 137.953419 92.336529) (xy 137.952596 92.336152) (xy 137.407157 92.060442) (xy 137.401319 92.053651)
+				(xy 137.401993 92.044722) (xy 137.407157 92.039558) (xy 137.952597 91.763846) (xy 137.961525 91.763173)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "36b319de-d106-47d5-b24f-6252e79a814f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30095)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 133.991424 112.731799) (xy 134.168201 112.908576) (xy 134.666671 112.649441) (xy 134.500707 112.399293)
+				(xy 134.250559 112.233329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 134.260333 112.239892) (xy 134.2614 112.240521) (xy 134.487419 112.390477) (xy 134.498734 112.397984)
+				(xy 134.502015 112.401265) (xy 134.659475 112.638595) (xy 134.661194 112.647383) (xy 134.656194 112.654812)
+				(xy 134.655123 112.655444) (xy 134.175808 112.904621) (xy 134.166887 112.905397) (xy 134.162138 112.902513)
+				(xy 133.997486 112.737861) (xy 133.994059 112.729588) (xy 133.995377 112.724194) (xy 134.244557 112.244874)
+				(xy 134.251412 112.239116)
+			)
+		)
+	)
+	(zone
+		(net 4)
+		(net_name "LD_short-")
+		(layer "F.Cu")
+		(uuid "36bd3a0a-f09b-4ce6-8200-906fea0ea913")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30027)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 121.9 111.625) (xy 121.9 111.875) (xy 122.4 112.25) (xy 123.001 111.75) (xy 122.4 111.25)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 122.407105 111.255911) (xy 122.846531 111.62149) (xy 122.990189 111.741006) (xy 122.994357 111.748931)
+				(xy 122.9917 111.757483) (xy 122.990189 111.758994) (xy 122.407107 112.244087) (xy 122.398555 112.246744)
+				(xy 122.392604 112.244453) (xy 121.90468 111.87851) (xy 121.900118 111.870805) (xy 121.9 111.86915)
+				(xy 121.9 111.63085) (xy 121.903427 111.622577) (xy 121.90468 111.62149) (xy 122.392606 111.255545)
+				(xy 122.401279 111.253324)
+			)
+		)
+	)
+	(zone
+		(net 36)
+		(net_name "-5V")
+		(layer "F.Cu")
+		(uuid "3b35c997-42ee-4bd0-8376-a9752acfb6df")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30051)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 140.42929 108.506066) (xy 140.606066 108.32929) (xy 140.909099 107.909099) (xy 140.499293 107.524293)
+				(xy 140.056042 107.85693)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 140.50646 107.531023) (xy 140.901605 107.902062) (xy 140.90529 107.910223) (xy 140.903086 107.917435)
+				(xy 140.606614 108.328529) (xy 140.605397 108.329958) (xy 140.440091 108.495264) (xy 140.431818 108.498691)
+				(xy 140.423545 108.495264) (xy 140.421675 108.492823) (xy 140.327645 108.32929) (xy 140.061201 107.865903)
+				(xy 140.060049 107.857025) (xy 140.06432 107.850717) (xy 140.49143 107.530193) (xy 140.500102 107.527969)
+			)
+		)
+	)
+	(zone
+		(net 30)
+		(net_name "V_diode+")
+		(layer "F.Cu")
+		(uuid "3c63a0c1-7043-44c9-9be8-1fc86ca02ccd")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30018)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 121.608882 102.244696) (xy 121.750304 102.386118) (xy 122.716809 102.04251) (xy 122.590707 101.404293)
+				(xy 121.95249 101.278191)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 122.583016 101.402773) (xy 122.590468 101.407738) (xy 122.592226 101.411983) (xy 122.714851 102.032601)
+				(xy 122.713093 102.041382) (xy 122.707292 102.045893) (xy 121.757268 102.383641) (xy 121.748325 102.383183)
+				(xy 121.745076 102.38089) (xy 121.614109 102.249923) (xy 121.610682 102.24165) (xy 121.611358 102.237731)
+				(xy 121.949107 101.287705) (xy 121.955106 101.28106) (xy 121.962395 101.280148)
+			)
+		)
+	)
+	(zone
+		(net 36)
+		(net_name "-5V")
+		(layer "F.Cu")
+		(uuid "3da41871-df19-4c66-9821-e2ba4d87571f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30063)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 143.95 108.85) (xy 144.45 108.85) (xy 144.5 108.4) (xy 144.2 107.8865) (xy 143.9 108.4)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 144.205902 107.899591) (xy 144.210102 107.903791) (xy 144.498046 108.396655) (xy 144.499572 108.403849)
+				(xy 144.451156 108.839592) (xy 144.446837 108.847436) (xy 144.439528 108.85) (xy 143.960472 108.85)
+				(xy 143.952199 108.846573) (xy 143.948844 108.839592) (xy 143.929477 108.665294) (xy 143.900427 108.403846)
+				(xy 143.901952 108.396658) (xy 144.189898 107.90379) (xy 144.19703 107.898376)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "437bda6e-a395-4b40-94b4-ea94795632cb")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30010)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 95.25 99.4) (xy 94.75 99.4) (xy 94.21903 100.354329) (xy 95 101.001) (xy 95.78097 100.354329)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 95.251394 99.403427) (xy 95.253345 99.406012) (xy 95.776241 100.345831) (xy 95.777269 100.354726)
+				(xy 95.773479 100.360531) (xy 95.007462 100.994821) (xy 94.998904 100.997458) (xy 94.992538 100.994821)
+				(xy 94.22652 100.360531) (xy 94.222333 100.352615) (xy 94.223758 100.345831) (xy 94.746655 99.406012)
+				(xy 94.753672 99.400448) (xy 94.756879 99.4) (xy 95.243121 99.4)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "48392f81-00ff-4375-9eee-b0e5ac89629c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30114)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 138.609616 114.35) (xy 138.609616 114.1) (xy 138.091473 114.255764) (xy 138.149 114.55) (xy 138.399441 114.716671)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 138.603457 114.105429) (xy 138.609121 114.112366) (xy 138.609616 114.115734) (xy 138.609616 114.346884)
+				(xy 138.608067 114.352702) (xy 138.405661 114.705819) (xy 138.398573 114.711293) (xy 138.389692 114.710152)
+				(xy 138.389028 114.709741) (xy 138.153064 114.552704) (xy 138.148075 114.545268) (xy 138.148063 114.545209)
+				(xy 138.110425 114.352702) (xy 138.093506 114.266162) (xy 138.095282 114.257386) (xy 138.10162 114.252713)
+				(xy 138.594549 114.104529)
+			)
+		)
+	)
+	(zone
+		(net 44)
+		(net_name "Net-(RN1A-R1.2)")
+		(layer "F.Cu")
+		(uuid "4cf58b75-4978-4e57-9910-94fbfe533000")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30097)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 129.9 110.625) (xy 129.65 110.625) (xy 129.582612 110.886732) (xy 129.775 111.6385) (xy 129.967388 110.886732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 129.899204 110.628427) (xy 129.902261 110.633783) (xy 129.966638 110.883822) (xy 129.966643 110.88964)
+				(xy 129.786335 111.594207) (xy 129.780964 111.601372) (xy 129.772099 111.602641) (xy 129.764934 111.59727)
+				(xy 129.763665 111.594207) (xy 129.583356 110.88964) (xy 129.583361 110.883822) (xy 129.647739 110.633783)
+				(xy 129.65312 110.626625) (xy 129.659069 110.625) (xy 129.890931 110.625)
+			)
+		)
+	)
+	(zone
+		(net 13)
+		(net_name "Net-(J1-In)")
+		(layer "F.Cu")
+		(uuid "50317a7d-f70b-4dcf-be01-06c3cba1c0a5")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30035)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 143.909099 114.985875) (xy 144.085875 114.809099) (xy 144.406389 114.5) (xy 143.749293 113.999293)
+				(xy 143.368913 114.5)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 143.758596 114.006381) (xy 144.395136 114.491425) (xy 144.395544 114.491736) (xy 144.400048 114.499476)
+				(xy 144.397759 114.508133) (xy 144.396575 114.509464) (xy 144.085855 114.809118) (xy 143.916945 114.978028)
+				(xy 143.908672 114.981455) (xy 143.900848 114.978454) (xy 143.900374 114.978028) (xy 143.376919 114.507201)
+				(xy 143.37306 114.499121) (xy 143.375427 114.491425) (xy 143.742206 114.008621) (xy 143.749939 114.004108)
+			)
+		)
+	)
+	(zone
+		(net 54)
+		(net_name "Net-(RN1C-R3.2)")
+		(layer "F.Cu")
+		(uuid "50f9e428-f116-4c47-a82a-0df7f06aa575")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30119)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 131.901776 110.739645) (xy 131.760355 110.598224) (xy 131.612388 110.827508) (xy 131.724293 111.638207)
+				(xy 131.925 110.925)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.768672 110.606912) (xy 131.770601 110.60847) (xy 131.898938 110.736807) (xy 131.902274 110.743625)
+				(xy 131.924705 110.922651) (xy 131.924359 110.927275) (xy 131.73948 111.58424) (xy 131.73394 111.591276)
+				(xy 131.725048 111.592334) (xy 131.718012 111.586794) (xy 131.716627 111.582671) (xy 131.612981 110.831806)
+				(xy 131.614739 110.823864) (xy 131.752498 110.610397) (xy 131.759863 110.605306)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "541e00b0-7be3-4168-9975-6c0c3f1aefbb")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30099)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 130.55 114.85) (xy 130.3 114.85) (xy 130.232612 115.111732) (xy 130.425 115.8635) (xy 130.617388 115.111732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 130.549204 114.853427) (xy 130.552261 114.858783) (xy 130.616638 115.108822) (xy 130.616643 115.11464)
+				(xy 130.436335 115.819207) (xy 130.430964 115.826372) (xy 130.422099 115.827641) (xy 130.414934 115.82227)
+				(xy 130.413665 115.819207) (xy 130.233356 115.11464) (xy 130.233361 115.108822) (xy 130.297739 114.858783)
+				(xy 130.30312 114.851625) (xy 130.309069 114.85) (xy 130.540931 114.85)
+			)
+		)
+	)
+	(zone
+		(net 14)
+		(net_name "Relay-")
+		(layer "F.Cu")
+		(uuid "5639d22c-95ac-4616-9630-0938cfb4b1a9")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30111)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 111.05 92.1875) (xy 111.05 91.9375) (xy 110.75 91.7625) (xy 110.449 92.0625) (xy 110.75 92.3625)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 110.757775 91.767035) (xy 111.044196 91.934114) (xy 111.049615 91.941241) (xy 111.05 91.944219)
+				(xy 111.05 92.18078) (xy 111.046573 92.189053) (xy 111.044195 92.190886) (xy 110.757777 92.357963)
+				(xy 110.748904 92.359172) (xy 110.743623 92.356144) (xy 110.575975 92.189053) (xy 110.457313 92.070785)
+				(xy 110.453873 92.062519) (xy 110.457285 92.054241) (xy 110.743624 91.768854) (xy 110.751901 91.765442)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "56da9ccf-c83f-43ab-9839-0e35aea222ff")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30081)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 126.409464 93.719089) (xy 126.055911 93.365536) (xy 125.645829 93.713059) (xy 125.811793 93.963207)
+				(xy 126.061941 94.129171)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 126.063529 93.373154) (xy 126.401845 93.71147) (xy 126.405272 93.719743) (xy 126.402498 93.727307)
+				(xy 126.068666 94.121234) (xy 126.060703 94.12533) (xy 126.053272 94.123419) (xy 125.813765 93.964515)
+				(xy 125.810484 93.961234) (xy 125.65158 93.721727) (xy 125.649861 93.712939) (xy 125.653764 93.706334)
+				(xy 126.047692 93.3725) (xy 126.056219 93.369767)
+			)
+		)
+	)
+	(zone
+		(net 7)
+		(net_name "Net-(RN1B-R2.2)")
+		(layer "F.Cu")
+		(uuid "581a167d-4dab-4d06-9639-992c85620c97")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30104)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 130.3 112.65) (xy 130.55 112.65) (xy 130.617388 112.388268) (xy 130.425 111.6365) (xy 130.232612 112.388268)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 130.435066 111.677729) (xy 130.436335 111.680792) (xy 130.616643 112.385359) (xy 130.616638 112.391177)
+				(xy 130.552261 112.641217) (xy 130.54688 112.648375) (xy 130.540931 112.65) (xy 130.309069 112.65)
+				(xy 130.300796 112.646573) (xy 130.297739 112.641217) (xy 130.233361 112.391177) (xy 130.233356 112.385359)
+				(xy 130.413665 111.680792) (xy 130.419036 111.673627) (xy 130.427901 111.672358)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "5a3766f8-196f-4e39-90c6-0b744a0491b1")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30039)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 134.425 111.6) (xy 134.425 111.35) (xy 133.836104 111.042127) (xy 133.499 111.475) (xy 133.836104 111.907873)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 133.844755 111.046649) (xy 134.418721 111.346717) (xy 134.424465 111.353587) (xy 134.425 111.357086)
+				(xy 134.425 111.592913) (xy 134.421573 111.601186) (xy 134.418721 111.603282) (xy 133.844756 111.903349)
+				(xy 133.835836 111.904145) (xy 133.830104 111.900169) (xy 133.504597 111.482188) (xy 133.502218 111.473556)
+				(xy 133.504597 111.467812) (xy 133.830106 111.049828) (xy 133.837891 111.045408)
+			)
+		)
+	)
+	(zone
+		(net 53)
+		(net_name "Net-(K1-Pad21)")
+		(layer "F.Cu")
+		(uuid "5c4cc3d4-9d0f-455c-91a0-ec2b1f2f2468")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30007)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 102.280677 107.072877) (xy 101.927123 106.719323) (xy 100.41509 106.149215) (xy 100.219293 107.130707)
+				(xy 100.77557 107.96147)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 100.427989 106.154078) (xy 101.924763 106.718433) (xy 101.928908 106.721108) (xy 102.270003 107.062203)
+				(xy 102.27343 107.070476) (xy 102.270003 107.078749) (xy 102.267678 107.080551) (xy 100.785089 107.955849)
+				(xy 100.776223 107.957104) (xy 100.769419 107.952284) (xy 100.221995 107.134742) (xy 100.22024 107.125961)
+				(xy 100.220243 107.125943) (xy 100.229299 107.080551) (xy 100.412392 106.162738) (xy 100.417371 106.155296)
+				(xy 100.426155 106.153554)
+			)
+		)
+	)
+	(zone
+		(net 14)
+		(net_name "Relay-")
+		(layer "F.Cu")
+		(uuid "5c9de60b-90f0-47dc-8888-c7115c6670ad")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30057)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 112.125 92.3) (xy 112.125 92.55) (xy 112.648463 92.809776) (xy 113.001 92.425) (xy 112.648463 92.040224)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 112.654407 92.046712) (xy 112.993758 92.417096) (xy 112.99682 92.425511) (xy 112.993758 92.432904)
+				(xy 112.654407 92.803287) (xy 112.646291 92.807072) (xy 112.640579 92.805863) (xy 112.131499 92.553225)
+				(xy 112.125612 92.546478) (xy 112.125 92.542745) (xy 112.125 92.307254) (xy 112.128427 92.298981)
+				(xy 112.131495 92.296776) (xy 112.64058 92.044135) (xy 112.649513 92.043528)
+			)
+		)
+	)
+	(zone
+		(net 53)
+		(net_name "Net-(K1-Pad21)")
+		(layer "F.Cu")
+		(uuid "5cc81a65-c947-42b8-8a57-8f3624fbfdb6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30049)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 102.25 104.875) (xy 102.75 104.875) (xy 102.9 104.427393) (xy 102.5 104.074) (xy 102.1 104.427393)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 102.507747 104.080844) (xy 102.894189 104.422259) (xy 102.89812 104.430305) (xy 102.897536 104.434745)
+				(xy 102.752675 104.867018) (xy 102.746797 104.873773) (xy 102.741581 104.875) (xy 102.258419 104.875)
+				(xy 102.250146 104.871573) (xy 102.247325 104.867018) (xy 102.102463 104.434743) (xy 102.103084 104.425811)
+				(xy 102.105807 104.422262) (xy 102.492253 104.080843) (xy 102.500722 104.077934)
+			)
+		)
+	)
+	(zone
+		(net 8)
+		(net_name "Net-(U1A-+)")
+		(layer "F.Cu")
+		(uuid "5e0821e9-0a44-4704-ba68-3c8a50744194")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30054)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 140.696967 115.498743) (xy 140.873743 115.321967) (xy 141.159099 114.909099) (xy 140.749293 114.524293)
+				(xy 140.312874 114.867154)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 140.756621 114.531174) (xy 141.1076 114.860742) (xy 141.151756 114.902204) (xy 141.155441 114.910365)
+				(xy 141.153372 114.917385) (xy 140.874344 115.321096) (xy 140.872992 115.322717) (xy 140.707498 115.488211)
+				(xy 140.699225 115.491638) (xy 140.690952 115.488211) (xy 140.689228 115.486017) (xy 140.318266 114.876021)
+				(xy 140.316896 114.867172) (xy 140.321034 114.860743) (xy 140.741387 114.530503) (xy 140.750009 114.528087)
+			)
+		)
+	)
+	(zone
+		(net 39)
+		(net_name "-12V")
+		(layer "F.Cu")
+		(uuid "5fcbf179-7629-4c08-865a-0f401e38ee68")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30042)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 123.125 93.0875) (xy 122.875 93.0875) (xy 122.5625 93.628835) (xy 123 93.9635) (xy 123.4375 93.628835)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 123.126518 93.090927) (xy 123.128378 93.093351) (xy 123.432362 93.619935) (xy 123.43353 93.628813)
+				(xy 123.429338 93.635077) (xy 123.007109 93.958061) (xy 122.998455 93.960366) (xy 122.992891 93.958061)
+				(xy 122.570661 93.635077) (xy 122.566172 93.627329) (xy 122.567636 93.619937) (xy 122.871622 93.09335)
+				(xy 122.878726 93.087899) (xy 122.881755 93.0875) (xy 123.118245 93.0875)
+			)
+		)
+	)
+	(zone
+		(net 2)
+		(net_name "Net-(J2-+5V)")
+		(layer "F.Cu")
+		(uuid "626a46fd-43d1-4775-8017-0993c691881b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30053)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 125.486243 95.590533) (xy 125.309467 95.413757) (xy 124.839962 95.116651) (xy 124.499293 95.538207)
+				(xy 124.839962 95.958349)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 124.848767 95.122223) (xy 125.308369 95.413062) (xy 125.310386 95.414676) (xy 125.475391 95.579681)
+				(xy 125.478818 95.587954) (xy 125.475391 95.596227) (xy 125.472905 95.598123) (xy 124.848586 95.95344)
+				(xy 124.839701 95.954553) (xy 124.833711 95.95064) (xy 124.541721 95.590533) (xy 124.505256 95.545561)
+				(xy 124.502708 95.536978) (xy 124.505243 95.530843) (xy 124.833413 95.124754) (xy 124.841276 95.120475)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "63327d60-94e9-4e5b-91ff-943bd25e84b7")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30102)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 135.15 112.65) (xy 135.4 112.65) (xy 135.467388 112.388268) (xy 135.275 111.6365) (xy 135.082612 112.388268)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 135.285066 111.677729) (xy 135.286335 111.680792) (xy 135.466643 112.385359) (xy 135.466638 112.391177)
+				(xy 135.402261 112.641217) (xy 135.39688 112.648375) (xy 135.390931 112.65) (xy 135.159069 112.65)
+				(xy 135.150796 112.646573) (xy 135.147739 112.641217) (xy 135.083361 112.391177) (xy 135.083356 112.385359)
+				(xy 135.263665 111.680792) (xy 135.269036 111.673627) (xy 135.277901 111.672358)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "64bfdd12-42a5-4aff-92c5-14e0f29cafea")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30079)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 125.218264 93.7125) (xy 125.218264 94.2125) (xy 125.753973 94.256736) (xy 125.8135 93.9625)
+				(xy 125.753973 93.668264)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 125.752131 93.671854) (xy 125.756035 93.67846) (xy 125.81303 93.96018) (xy 125.81303 93.96482)
+				(xy 125.756035 94.246539) (xy 125.751035 94.253968) (xy 125.743604 94.255879) (xy 125.229001 94.213386)
+				(xy 125.221038 94.20929) (xy 125.218264 94.201726) (xy 125.218264 93.723273) (xy 125.221691 93.715)
+				(xy 125.228999 93.711613) (xy 125.743604 93.66912)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "Net-(J2-DDCCL)")
+		(layer "F.Cu")
+		(uuid "67f87260-0989-4fc5-8b4c-87afde49d4a7")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30052)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 122.190533 95.413757) (xy 122.013757 95.590533) (xy 122.660038 95.958349) (xy 123.000707 95.538207)
+				(xy 122.660038 95.116651)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 122.666587 95.124755) (xy 122.899574 95.413062) (xy 122.994754 95.53084) (xy 122.997289 95.539429)
+				(xy 122.994742 95.545563) (xy 122.666288 95.95064) (xy 122.658416 95.954908) (xy 122.651413 95.95344)
+				(xy 122.027094 95.598123) (xy 122.021599 95.591052) (xy 122.022712 95.582167) (xy 122.024604 95.579685)
+				(xy 122.189618 95.414671) (xy 122.191625 95.413065) (xy 122.651233 95.122222) (xy 122.660055 95.120695)
+			)
+		)
+	)
+	(zone
+		(net 47)
+		(net_name "Net-(C6-Pad1)")
+		(layer "F.Cu")
+		(uuid "6a5f361f-b701-4ba8-a4f7-c1be606a6a09")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30048)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 123.175 103.75) (xy 123.175 104.25) (xy 123.622607 104.4) (xy 123.976 104) (xy 123.622607 103.6)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 123.624188 103.603084) (xy 123.62774 103.60581) (xy 123.969155 103.992253) (xy 123.972065 104.000722)
+				(xy 123.969155 104.007747) (xy 123.62774 104.394189) (xy 123.619694 104.39812) (xy 123.615254 104.397536)
+				(xy 123.605266 104.394189) (xy 123.570251 104.382454) (xy 123.182982 104.252674) (xy 123.176227 104.246796)
+				(xy 123.175 104.24158) (xy 123.175 103.758419) (xy 123.178427 103.750146) (xy 123.182982 103.747325)
+				(xy 123.615256 103.602463)
+			)
+		)
+	)
+	(zone
+		(net 12)
+		(net_name "Net-(D4-A)")
+		(layer "F.Cu")
+		(uuid "6d39d40e-bd01-423c-81ad-193ed786642c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30050)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 102.75 101.625) (xy 102.25 101.625) (xy 102.1 102.072606) (xy 102.5 102.426) (xy 102.9 102.072606)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 102.749854 101.628427) (xy 102.752675 101.632982) (xy 102.897536 102.065253) (xy 102.896915 102.074187)
+				(xy 102.894189 102.077739) (xy 102.507747 102.419155) (xy 102.499278 102.422065) (xy 102.492253 102.419155)
+				(xy 102.10581 102.077739) (xy 102.101879 102.069693) (xy 102.102462 102.065258) (xy 102.247325 101.632981)
+				(xy 102.253203 101.626227) (xy 102.258419 101.625) (xy 102.741581 101.625)
+			)
+		)
+	)
+	(zone
+		(net 42)
+		(net_name "Net-(J5-Pin_1)")
+		(layer "F.Cu")
+		(uuid "73c2740b-0ad0-49e1-b7a9-2e1cb449a419")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30006)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 151.75 97.494695) (xy 151.25 97.494695) (xy 150.647744 98.930541) (xy 151.5 99.501) (xy 152.352256 98.930541)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 151.750493 97.498122) (xy 151.753009 97.501869) (xy 152.348527 98.921652) (xy 152.348567 98.930607)
+				(xy 152.344246 98.935901) (xy 151.506508 99.496643) (xy 151.497727 99.498397) (xy 151.493492 99.496643)
+				(xy 150.655753 98.935901) (xy 150.650784 98.928451) (xy 150.651472 98.921652) (xy 151.246991 97.501869)
+				(xy 151.253351 97.495566) (xy 151.25778 97.494695) (xy 151.74222 97.494695)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "761fbd4b-ef34-4bd3-9b30-989edc3df008")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30032)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 120.375 104.925) (xy 120.875 104.925) (xy 121.057873 104.336104) (xy 120.625 103.999) (xy 120.192127 104.336104)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 120.632187 104.004597) (xy 120.950857 104.252764) (xy 121.051487 104.331131) (xy 121.055909 104.338918)
+				(xy 121.055472 104.343832) (xy 120.877556 104.91677) (xy 120.871829 104.923654) (xy 120.866382 104.925)
+				(xy 120.383618 104.925) (xy 120.375345 104.921573) (xy 120.372444 104.91677) (xy 120.194527 104.343832)
+				(xy 120.195347 104.334915) (xy 120.19851 104.331132) (xy 120.617811 104.004597) (xy 120.626444 104.002218)
+			)
+		)
+	)
+	(zone
+		(net 54)
+		(net_name "Net-(RN1C-R3.2)")
+		(layer "F.Cu")
+		(uuid "76209c24-bd39-4e14-9fc7-5e59b46a0617")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30118)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 131.216421 110.725) (xy 131.075 110.583579) (xy 130.932012 110.835765) (xy 131.074293 111.638207)
+				(xy 131.267388 110.886732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.083367 110.592543) (xy 131.085869 110.594448) (xy 131.214395 110.722974) (xy 131.217281 110.72773)
+				(xy 131.266382 110.883541) (xy 131.266555 110.88997) (xy 131.087723 111.585939) (xy 131.082345 111.593099)
+				(xy 131.073479 111.594359) (xy 131.066319 111.588981) (xy 131.064871 111.58507) (xy 130.932747 110.839912)
+				(xy 130.934088 110.832102) (xy 131.067419 110.596948) (xy 131.07448 110.591444)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "777dfa52-bc82-40fe-bc6a-8c99caeafb78")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30022)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 130.775 91.55) (xy 130.775 92.05) (xy 131.429329 92.28097) (xy 132.001 91.8) (xy 131.429329 91.31903)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.431963 91.321734) (xy 131.434447 91.323336) (xy 131.990358 91.791047) (xy 131.994483 91.798996)
+				(xy 131.991779 91.807532) (xy 131.990358 91.808953) (xy 131.434447 92.276663) (xy 131.425911 92.279367)
+				(xy 131.423021 92.278743) (xy 130.782806 92.052755) (xy 130.776145 92.04677) (xy 130.775 92.041722)
+				(xy 130.775 91.558277) (xy 130.778427 91.550004) (xy 130.782803 91.547245) (xy 131.423022 91.321256)
+			)
+		)
+	)
+	(zone
+		(net 36)
+		(net_name "-5V")
+		(layer "F.Cu")
+		(uuid "7a855a87-5dd7-4511-a141-c93d7dc27780")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30038)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 138.075 115.65) (xy 138.075 115.9) (xy 138.663896 116.207873) (xy 139.001 115.775) (xy 138.663896 115.342127)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 138.669895 115.34983) (xy 138.995401 115.767811) (xy 138.997781 115.776444) (xy 138.995401 115.782189)
+				(xy 138.669895 116.200169) (xy 138.662108 116.204591) (xy 138.655243 116.203349) (xy 138.081279 115.903282)
+				(xy 138.075535 115.896412) (xy 138.075 115.892913) (xy 138.075 115.657086) (xy 138.078427 115.648813)
+				(xy 138.081277 115.646718) (xy 138.655244 115.346649) (xy 138.664163 115.345854)
+			)
+		)
+	)
+	(zone
+		(net 39)
+		(net_name "-12V")
+		(layer "F.Cu")
+		(uuid "7c53dc04-417d-449b-8151-2c9d8968cc7a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30085)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 143.108579 106.464645) (xy 143.285355 106.641421) (xy 143.516751 106.215074) (xy 143.250707 105.611793)
+				(xy 142.961418 106.182403)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 143.255261 105.628683) (xy 143.260675 105.634397) (xy 143.514433 106.209819) (xy 143.514636 106.218772)
+				(xy 143.514011 106.220121) (xy 143.29283 106.627648) (xy 143.285872 106.633285) (xy 143.276966 106.63235)
+				(xy 143.274274 106.63034) (xy 143.109848 106.465914) (xy 143.107747 106.46305) (xy 142.978452 106.215074)
+				(xy 142.964198 106.187736) (xy 142.963412 106.178817) (xy 142.964138 106.177037) (xy 143.239537 105.633825)
+				(xy 143.246332 105.627998)
+			)
+		)
+	)
+	(zone
+		(net 11)
+		(net_name "Net-(D2-A)")
+		(layer "F.Cu")
+		(uuid "7d3e2832-c5e9-4fcb-98a8-94bb9958ca16")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30090)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 107.95 91.8125) (xy 107.95 92.3125) (xy 108.25 92.3625) (xy 108.551 92.0625) (xy 108.25 91.7625)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 108.252796 91.765507) (xy 108.254255 91.766741) (xy 108.542685 92.054213) (xy 108.546126 92.062481)
+				(xy 108.542713 92.070759) (xy 108.542685 92.070787) (xy 108.254255 92.358258) (xy 108.245977 92.361671)
+				(xy 108.244073 92.361512) (xy 107.959777 92.314129) (xy 107.952179 92.309388) (xy 107.95 92.302588)
+				(xy 107.95 91.822411) (xy 107.953427 91.814138) (xy 107.959775 91.81087) (xy 108.244075 91.763487)
+			)
+		)
+	)
+	(zone
+		(net 39)
+		(net_name "-12V")
+		(layer "F.Cu")
+		(uuid "7f457797-94e4-44d7-9907-05776301be93")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30037)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 142.411611 104.588387) (xy 142.588387 104.411611) (xy 142.78097 104.070671) (xy 142.299293 103.499293)
+				(xy 141.92747 104.188023)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 142.306982 103.509677) (xy 142.310367 103.512429) (xy 142.766628 104.053659) (xy 142.775729 104.064454)
+				(xy 142.778442 104.072988) (xy 142.776971 104.077749) (xy 142.589172 104.41022) (xy 142.587258 104.412739)
+				(xy 142.419137 104.58086) (xy 142.410864 104.584287) (xy 142.403408 104.581603) (xy 141.934872 104.194144)
+				(xy 141.93068 104.186231) (xy 141.932032 104.179571) (xy 142.29113 103.514413) (xy 142.298074 103.508762)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "81774ba6-c5cc-4f97-b106-386edb2f263a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30062)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 134.15 91.8) (xy 134.15 92.3) (xy 134.6 92.35) (xy 135.1135 92.05) (xy 134.6 91.75)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 134.603342 91.751952) (xy 134.899062 91.92472) (xy 135.096208 92.039898) (xy 135.101623 92.04703)
+				(xy 135.100408 92.055902) (xy 135.096208 92.060102) (xy 134.603344 92.348046) (xy 134.59615 92.349572)
+				(xy 134.160408 92.301156) (xy 134.152564 92.296837) (xy 134.15 92.289528) (xy 134.15 91.810471)
+				(xy 134.153427 91.802198) (xy 134.160406 91.798843) (xy 134.596152 91.750427)
+			)
+		)
+	)
+	(zone
+		(net 44)
+		(net_name "Net-(RN1A-R1.2)")
+		(layer "F.Cu")
+		(uuid "8343808f-2432-4bbe-8901-1e31e0100faa")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30044)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 131.783594 109.550015) (xy 131.925015 109.408594) (xy 131.675 108.734314) (xy 131.199293 108.824293)
+				(xy 131.034314 109.225)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.674056 108.737979) (xy 131.678435 108.743578) (xy 131.922406 109.401558) (xy 131.922069 109.410507)
+				(xy 131.919709 109.413899) (xy 131.789221 109.544387) (xy 131.780948 109.547814) (xy 131.776293 109.546848)
+				(xy 131.381936 109.375787) (xy 131.044848 109.229569) (xy 131.038622 109.223133) (xy 131.038684 109.214383)
+				(xy 131.196879 108.830154) (xy 131.203197 108.82381) (xy 131.205517 108.823115) (xy 131.665292 108.73615)
+			)
+		)
+	)
+	(zone
+		(net 31)
+		(net_name "V_diode-")
+		(layer "F.Cu")
+		(uuid "8e50591f-4fee-4519-856a-dc6acf11781a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30017)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 119.703882 102.244696) (xy 119.845304 102.386118) (xy 120.811809 102.04251) (xy 120.685707 101.404293)
+				(xy 120.04749 101.278191)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 120.678016 101.402773) (xy 120.685468 101.407738) (xy 120.687226 101.411983) (xy 120.809851 102.032601)
+				(xy 120.808093 102.041382) (xy 120.802292 102.045893) (xy 120.090845 102.298824) (xy 120.086926 102.2995)
+				(xy 120.060435 102.2995) (xy 119.984012 102.319977) (xy 119.984008 102.319979) (xy 119.915488 102.359539)
+				(xy 119.914828 102.3602) (xy 119.910477 102.362947) (xy 119.852268 102.383641) (xy 119.843325 102.383183)
+				(xy 119.840076 102.38089) (xy 119.709109 102.249923) (xy 119.705682 102.24165) (xy 119.706358 102.237731)
+				(xy 120.044107 101.287705) (xy 120.050106 101.28106) (xy 120.057395 101.280148)
+			)
+		)
+	)
+	(zone
+		(net 46)
+		(net_name "Net-(RN1A-R1.1)")
+		(layer "F.Cu")
+		(uuid "8e82ff49-f789-4150-b291-3057e32c9d0a")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30116)
@@ -23068,13 +25362,13 @@
 		)
 	)
 	(zone
-		(net 37)
-		(net_name "+12V")
+		(net 6)
+		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "0d55164a-9cbe-4741-bdbc-5d99abdaf1f0")
+		(uuid "8ec648ef-b326-4a88-8167-35c8063fa4cb")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30092)
+		(priority 30080)
 		(attr
 			(teardrop
 				(type padvia)
@@ -23093,27 +25387,24 @@
 		)
 		(polygon
 			(pts
-				(xy 116.805764 95.175) (xy 116.805764 95.425) (xy 117.341473 95.594236) (xy 117.401 95.3) (xy 117.341473 95.005764)
+				(xy 134.394236 93.25) (xy 134.394236 92.75) (xy 133.858527 92.705764) (xy 133.799 93) (xy 133.858527 93.294236)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 117.337983 95.01046) (xy 117.343743 95.017317) (xy 117.344054 95.018521) (xy 117.40053 95.29768)
-				(xy 117.40053 95.30232) (xy 117.344054 95.581478) (xy 117.339054 95.588907) (xy 117.330266 95.590626)
-				(xy 117.329062 95.590315) (xy 116.81394 95.427582) (xy 116.807083 95.421822) (xy 116.805764 95.416425)
-				(xy 116.805764 95.183574) (xy 116.809191 95.175301) (xy 116.81394 95.172417) (xy 117.329063 95.009684)
+				(xy 134.394236 92.75) (xy 134.394236 93.25) (xy 133.858527 93.294236) (xy 133.799 93) (xy 133.858527 92.705764)
 			)
 		)
 	)
 	(zone
-		(net 4)
-		(net_name "LD_short-")
+		(net 36)
+		(net_name "-5V")
 		(layer "F.Cu")
-		(uuid "0ec24e9e-9e69-4d84-a752-3825ddb56f40")
+		(uuid "9269052c-7179-41f3-a4de-f866f6de49ba")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
-		(priority 30024)
+		(priority 30124)
 		(attr
 			(teardrop
 				(type padvia)
@@ -23132,16 +25423,135 @@
 		)
 		(polygon
 			(pts
-				(xy 116.68 114.75) (xy 116.68 115.25) (xy 117.301804 115.525) (xy 117.731 115) (xy 117.301804 114.475)
+				(xy 137.625 115.9875) (xy 137.625 115.7375) (xy 137.425 115.6625) (xy 137.224 115.8625) (xy 137.425 116.0625)
 			)
 		)
 		(filled_polygon
 			(layer "F.Cu")
 			(pts
-				(xy 117.307444 114.481899) (xy 117.724946 114.992595) (xy 117.727529 115.001169) (xy 117.724946 115.007405)
-				(xy 117.307444 115.5181) (xy 117.299555 115.522336) (xy 117.293654 115.521395) (xy 116.686968 115.253081)
-				(xy 116.680788 115.246601) (xy 116.68 115.242381) (xy 116.68 114.757618) (xy 116.683427 114.749345)
-				(xy 116.686966 114.746918) (xy 117.293655 114.478603) (xy 117.302606 114.478392)
+				(xy 137.43203 115.665136) (xy 137.617408 115.734653) (xy 137.623951 115.740767) (xy 137.625 115.745608)
+				(xy 137.625 115.979392) (xy 137.621573 115.987665) (xy 137.617408 115.990347) (xy 137.432034 116.059862)
+				(xy 137.423084 116.059558) (xy 137.419675 116.057202) (xy 137.232334 115.870793) (xy 137.228887 115.862529)
+				(xy 137.232293 115.854248) (xy 137.419677 115.667796) (xy 137.427955 115.664392)
+			)
+		)
+	)
+	(zone
+		(net 9)
+		(net_name "Net-(U2-BYP)")
+		(layer "F.Cu")
+		(uuid "956b259e-67ec-48b5-b064-f3b2b5e13e4a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30045)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 138.515901 93.507323) (xy 138.692677 93.684099) (xy 139.163896 93.957873) (xy 139.500707 93.524293)
+				(xy 139.151027 93.100725)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 139.157626 93.108719) (xy 139.367923 93.363451) (xy 139.488357 93.509334) (xy 139.494741 93.517066)
+				(xy 139.497365 93.525628) (xy 139.494958 93.531693) (xy 139.17017 93.949795) (xy 139.162388 93.954226)
+				(xy 139.155052 93.952734) (xy 138.693992 93.684863) (xy 138.691597 93.683019) (xy 138.526185 93.517607)
+				(xy 138.522758 93.509334) (xy 138.526185 93.501061) (xy 138.528141 93.499486) (xy 139.142297 93.106313)
+				(xy 139.15111 93.10474)
+			)
+		)
+	)
+	(zone
+		(net 7)
+		(net_name "Net-(RN1B-R2.2)")
+		(layer "F.Cu")
+		(uuid "957fbe66-704c-4996-b2b1-b82a968a42c9")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30105)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 130.525 110.625) (xy 130.325 110.625) (xy 130.232612 110.886732) (xy 130.425 111.6385) (xy 130.617388 110.886732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 130.524995 110.628427) (xy 130.527755 110.632806) (xy 130.616204 110.88338) (xy 130.616506 110.890175)
+				(xy 130.436335 111.594207) (xy 130.430964 111.601372) (xy 130.422099 111.602641) (xy 130.414934 111.59727)
+				(xy 130.413665 111.594207) (xy 130.233493 110.890175) (xy 130.233795 110.88338) (xy 130.322245 110.632806)
+				(xy 130.32823 110.626145) (xy 130.333278 110.625) (xy 130.516722 110.625)
+			)
+		)
+	)
+	(zone
+		(net 47)
+		(net_name "Net-(C6-Pad1)")
+		(layer "F.Cu")
+		(uuid "96986383-4340-4141-ab2b-b6926f94f687")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30031)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 123.075 104.25) (xy 123.075 103.75) (xy 122.497887 103.55) (xy 122.174 104) (xy 122.497887 104.45)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 122.506122 103.552854) (xy 123.067132 103.747273) (xy 123.073826 103.753219) (xy 123.075 103.758327)
+				(xy 123.075 104.241672) (xy 123.071573 104.249945) (xy 123.067131 104.252727) (xy 122.506122 104.447145)
+				(xy 122.497183 104.446616) (xy 122.492795 104.442925) (xy 122.178919 104.006835) (xy 122.176867 103.998118)
+				(xy 122.178919 103.993165) (xy 122.492795 103.557073) (xy 122.500409 103.552361)
 			)
 		)
 	)
@@ -23149,7 +25559,7 @@
 		(net 4)
 		(net_name "LD_short-")
 		(layer "F.Cu")
-		(uuid "0f42e0d6-e128-4192-9842-020923062a1a")
+		(uuid "976ac7af-d330-4142-ae2f-8d27387890f5")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30023)
@@ -23188,87 +25598,7 @@
 		(net 41)
 		(net_name "Curr_Mod")
 		(layer "F.Cu")
-		(uuid "1156eb42-f43f-4da2-a691-6a0e6e1cf4ee")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30014)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 120.073007 114.280546) (xy 119.719454 113.926993) (xy 119.007538 114.25) (xy 118.999293 115.000707)
-				(xy 119.525 115.217462)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 119.725183 113.932722) (xy 120.066621 114.27416) (xy 120.070048 114.282433) (xy 120.068447 114.28834)
-				(xy 119.530142 115.208669) (xy 119.523007 115.21408) (xy 119.515583 115.213579) (xy 119.006619 115.003727)
-				(xy 119.000277 114.997405) (xy 118.99938 114.992782) (xy 119.007182 114.282433) (xy 119.007456 114.257448)
-				(xy 119.010973 114.249213) (xy 119.014319 114.246923) (xy 119.712077 113.930339) (xy 119.721026 113.930043)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "15ee2769-7766-4322-919e-d47cb6c83234")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30036)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 134.381586 112.695191) (xy 134.204809 112.518414) (xy 133.389192 112.575) (xy 133.499293 113.025707)
-				(xy 133.967554 113.287429)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 134.207984 112.521628) (xy 134.208576 112.522181) (xy 134.374649 112.688254) (xy 134.378076 112.696527)
-				(xy 134.375965 112.703231) (xy 133.973615 113.278758) (xy 133.966066 113.283575) (xy 133.958318 113.282267)
-				(xy 133.503741 113.028193) (xy 133.498191 113.021165) (xy 133.49809 113.020783) (xy 133.392486 112.588485)
-				(xy 133.393852 112.579637) (xy 133.401076 112.574345) (xy 133.40304 112.574039) (xy 134.199495 112.518782)
-			)
-		)
-	)
-	(zone
-		(net 41)
-		(net_name "Curr_Mod")
-		(layer "F.Cu")
-		(uuid "1657519a-fa2c-47e8-8097-e8896f214fb0")
+		(uuid "97c9746c-7c88-4332-998d-b96f8e24faa8")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30000)
@@ -23309,3720 +25639,7 @@
 		(net 37)
 		(net_name "+12V")
 		(layer "F.Cu")
-		(uuid "16a671bc-76e8-4377-bf32-9f7217734298")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30041)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 98.8 95.625) (xy 98.8 95.375) (xy 98.335082 95.05) (xy 97.899 95.5) (xy 98.335082 95.95)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 98.34325 95.05571) (xy 98.795003 95.371507) (xy 98.799821 95.379054) (xy 98.8 95.381095) (xy 98.8 95.618904)
-				(xy 98.796573 95.627177) (xy 98.795003 95.628493) (xy 98.34325 95.944289) (xy 98.334506 95.946221)
-				(xy 98.328145 95.942842) (xy 98.022243 95.627177) (xy 97.906889 95.508141) (xy 97.903593 95.499816)
-				(xy 97.90689 95.491858) (xy 98.016205 95.379054) (xy 98.328147 95.057155) (xy 98.336363 95.0536)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "Net-(J2-DDCCL)")
-		(layer "F.Cu")
-		(uuid "18014521-7e07-4b61-a52c-4fdbd534520c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30052)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 122.190533 95.413757) (xy 122.013757 95.590533) (xy 122.660038 95.958349) (xy 123.000707 95.538207)
-				(xy 122.660038 95.116651)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 122.666587 95.124755) (xy 122.899574 95.413062) (xy 122.994754 95.53084) (xy 122.997289 95.539429)
-				(xy 122.994742 95.545563) (xy 122.666288 95.95064) (xy 122.658416 95.954908) (xy 122.651413 95.95344)
-				(xy 122.027094 95.598123) (xy 122.021599 95.591052) (xy 122.022712 95.582167) (xy 122.024604 95.579685)
-				(xy 122.189618 95.414671) (xy 122.191625 95.413065) (xy 122.651233 95.122222) (xy 122.660055 95.120695)
-			)
-		)
-	)
-	(zone
-		(net 36)
-		(net_name "-5V")
-		(layer "F.Cu")
-		(uuid "19282e19-595e-44c3-8fbe-77638df72ed5")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30124)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 137.625 115.9875) (xy 137.625 115.7375) (xy 137.425 115.6625) (xy 137.224 115.8625) (xy 137.425 116.0625)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 137.43203 115.665136) (xy 137.617408 115.734653) (xy 137.623951 115.740767) (xy 137.625 115.745608)
-				(xy 137.625 115.979392) (xy 137.621573 115.987665) (xy 137.617408 115.990347) (xy 137.432034 116.059862)
-				(xy 137.423084 116.059558) (xy 137.419675 116.057202) (xy 137.232334 115.870793) (xy 137.228887 115.862529)
-				(xy 137.232293 115.854248) (xy 137.419677 115.667796) (xy 137.427955 115.664392)
-			)
-		)
-	)
-	(zone
-		(net 9)
-		(net_name "Net-(U2-BYP)")
-		(layer "F.Cu")
-		(uuid "1b232ab5-abb9-40fe-bdc7-3a27f389ef82")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30045)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 138.515901 93.507323) (xy 138.692677 93.684099) (xy 139.163896 93.957873) (xy 139.500707 93.524293)
-				(xy 139.151027 93.100725)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 139.157626 93.108719) (xy 139.367923 93.363451) (xy 139.488357 93.509334) (xy 139.494741 93.517066)
-				(xy 139.497365 93.525628) (xy 139.494958 93.531693) (xy 139.17017 93.949795) (xy 139.162388 93.954226)
-				(xy 139.155052 93.952734) (xy 138.693992 93.684863) (xy 138.691597 93.683019) (xy 138.526185 93.517607)
-				(xy 138.522758 93.509334) (xy 138.526185 93.501061) (xy 138.528141 93.499486) (xy 139.142297 93.106313)
-				(xy 139.15111 93.10474)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "1c37a530-b8fc-42e6-aafb-99a31ce3e686")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30029)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 94.35 96.55) (xy 94.85 96.55) (xy 95.032873 95.961104) (xy 94.6 95.499) (xy 94.167127 95.961104)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 94.607999 95.507575) (xy 94.608529 95.508105) (xy 95.028219 95.956136) (xy 95.031374 95.964516)
-				(xy 95.030854 95.967604) (xy 94.852556 96.54177) (xy 94.846829 96.548654) (xy 94.841382 96.55) (xy 94.358618 96.55)
-				(xy 94.350345 96.546573) (xy 94.347444 96.54177) (xy 94.169145 95.967604) (xy 94.169965 95.958687)
-				(xy 94.171774 95.956142) (xy 94.591462 95.508114) (xy 94.599618 95.50442)
-			)
-		)
-	)
-	(zone
-		(net 14)
-		(net_name "Relay-")
-		(layer "F.Cu")
-		(uuid "1ca2dcde-573e-4e96-b90e-f7980ba2a698")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30057)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 112.125 92.3) (xy 112.125 92.55) (xy 112.648463 92.809776) (xy 113.001 92.425) (xy 112.648463 92.040224)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 112.654407 92.046712) (xy 112.993758 92.417096) (xy 112.99682 92.425511) (xy 112.993758 92.432904)
-				(xy 112.654407 92.803287) (xy 112.646291 92.807072) (xy 112.640579 92.805863) (xy 112.131499 92.553225)
-				(xy 112.125612 92.546478) (xy 112.125 92.542745) (xy 112.125 92.307254) (xy 112.128427 92.298981)
-				(xy 112.131495 92.296776) (xy 112.64058 92.044135) (xy 112.649513 92.043528)
-			)
-		)
-	)
-	(zone
-		(net 36)
-		(net_name "-5V")
-		(layer "F.Cu")
-		(uuid "23180e47-f5a4-4638-9677-043282ee001e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30063)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 143.95 108.85) (xy 144.45 108.85) (xy 144.5 108.4) (xy 144.2 107.8865) (xy 143.9 108.4)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 144.205902 107.899591) (xy 144.210102 107.903791) (xy 144.498046 108.396655) (xy 144.499572 108.403849)
-				(xy 144.451156 108.839592) (xy 144.446837 108.847436) (xy 144.439528 108.85) (xy 143.960472 108.85)
-				(xy 143.952199 108.846573) (xy 143.948844 108.839592) (xy 143.929477 108.665294) (xy 143.900427 108.403846)
-				(xy 143.901952 108.396658) (xy 144.189898 107.90379) (xy 144.19703 107.898376)
-			)
-		)
-	)
-	(zone
-		(net 39)
-		(net_name "-12V")
-		(layer "F.Cu")
-		(uuid "2547e1de-7e36-4823-a721-e84e90ad5cbf")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30085)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 143.108579 106.464645) (xy 143.285355 106.641421) (xy 143.516751 106.215074) (xy 143.250707 105.611793)
-				(xy 142.961418 106.182403)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 143.255261 105.628683) (xy 143.260675 105.634397) (xy 143.514433 106.209819) (xy 143.514636 106.218772)
-				(xy 143.514011 106.220121) (xy 143.29283 106.627648) (xy 143.285872 106.633285) (xy 143.276966 106.63235)
-				(xy 143.274274 106.63034) (xy 143.109848 106.465914) (xy 143.107747 106.46305) (xy 142.978452 106.215074)
-				(xy 142.964198 106.187736) (xy 142.963412 106.178817) (xy 142.964138 106.177037) (xy 143.239537 105.633825)
-				(xy 143.246332 105.627998)
-			)
-		)
-	)
-	(zone
-		(net 2)
-		(net_name "Net-(J2-+5V)")
-		(layer "F.Cu")
-		(uuid "25f054f6-170d-4e5a-8a5d-100d99b5b7dd")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30019)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 125.476118 98.660304) (xy 125.334696 98.518882) (xy 124.368191 98.86249) (xy 124.494293 99.500707)
-				(xy 125.13251 99.626809)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 125.336674 98.521816) (xy 125.339923 98.524109) (xy 125.47089 98.655076) (xy 125.474317 98.663349)
-				(xy 125.473641 98.667268) (xy 125.135893 99.617292) (xy 125.129893 99.623939) (xy 125.122601 99.624851)
-				(xy 124.501983 99.502226) (xy 124.494531 99.497261) (xy 124.492773 99.493016) (xy 124.370148 98.872396)
-				(xy 124.371906 98.863617) (xy 124.377704 98.859107) (xy 125.327731 98.521358)
-			)
-		)
-	)
-	(zone
-		(net 7)
-		(net_name "Net-(RN1B-R2.2)")
-		(layer "F.Cu")
-		(uuid "26cb5b27-53fb-491a-95cc-51499a9f00a4")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30123)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 132.125 115.9875) (xy 132.125 115.7375) (xy 131.925 115.6625) (xy 131.724 115.8625) (xy 131.925 116.0625)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.93203 115.665136) (xy 132.117408 115.734653) (xy 132.123951 115.740767) (xy 132.125 115.745608)
-				(xy 132.125 115.979392) (xy 132.121573 115.987665) (xy 132.117408 115.990347) (xy 131.932034 116.059862)
-				(xy 131.923084 116.059558) (xy 131.919675 116.057202) (xy 131.732334 115.870793) (xy 131.728887 115.862529)
-				(xy 131.732293 115.854248) (xy 131.919677 115.667796) (xy 131.927955 115.664392)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "27c5605c-7286-496f-aaf8-dec5b7084e1d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30102)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 135.15 112.65) (xy 135.4 112.65) (xy 135.467388 112.388268) (xy 135.275 111.6365) (xy 135.082612 112.388268)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 135.285066 111.677729) (xy 135.286335 111.680792) (xy 135.466643 112.385359) (xy 135.466638 112.391177)
-				(xy 135.402261 112.641217) (xy 135.39688 112.648375) (xy 135.390931 112.65) (xy 135.159069 112.65)
-				(xy 135.150796 112.646573) (xy 135.147739 112.641217) (xy 135.083361 112.391177) (xy 135.083356 112.385359)
-				(xy 135.263665 111.680792) (xy 135.269036 111.673627) (xy 135.277901 111.672358)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "Net-(J2-DDCCL)")
-		(layer "F.Cu")
-		(uuid "29050b07-880c-4a85-a957-6c542ee162a6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30016)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 123.672981 96.596205) (xy 123.496205 96.772981) (xy 123.85749 97.721809) (xy 124.495707 97.595707)
-				(xy 124.621809 96.95749)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 123.680057 96.598899) (xy 124.612579 96.953975) (xy 124.619092 96.960121) (xy 124.619894 96.967177)
-				(xy 124.497226 97.588016) (xy 124.492261 97.595468) (xy 124.488016 97.597226) (xy 123.867177 97.719894)
-				(xy 123.858396 97.718136) (xy 123.853975 97.712579) (xy 123.810052 97.597226) (xy 123.4989 96.780058)
-				(xy 123.499158 96.771109) (xy 123.501558 96.767627) (xy 123.667625 96.60156) (xy 123.675897 96.598134)
-			)
-		)
-	)
-	(zone
-		(net 41)
-		(net_name "Curr_Mod")
-		(layer "F.Cu")
-		(uuid "2ccbfc80-5bf6-410b-a9f9-64b34ea3c0cf")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30088)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 121.318683 113.391907) (xy 121.141907 113.568683) (xy 121.4 113.784332) (xy 122.100707 113.750707)
-				(xy 122.134853 113.51)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 121.324478 113.392745) (xy 122.123305 113.508329) (xy 122.131003 113.512905) (xy 122.133214 113.521551)
-				(xy 122.102066 113.741126) (xy 122.097511 113.748836) (xy 122.091043 113.75117) (xy 121.404558 113.784113)
-				(xy 121.396496 113.781404) (xy 121.151725 113.576886) (xy 121.147574 113.568952) (xy 121.150249 113.560406)
-				(xy 121.150943 113.559646) (xy 121.314538 113.396051) (xy 121.32281 113.392625)
-			)
-		)
-	)
-	(zone
-		(net 42)
-		(net_name "Net-(J5-Pin_1)")
-		(layer "F.Cu")
-		(uuid "2dc82416-0efa-4eea-bb86-1cac88caff97")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30004)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 151.109619 94.713172) (xy 151.463172 94.359619) (xy 151.45 93.427208) (xy 149.749293 92.999293)
-				(xy 149.377208 93.9)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 151.441282 93.425014) (xy 151.448469 93.430356) (xy 151.450126 93.436195) (xy 151.463102 94.354676)
-				(xy 151.459792 94.362996) (xy 151.459676 94.363114) (xy 151.115427 94.707363) (xy 151.107154 94.71079)
-				(xy 151.102183 94.709681) (xy 149.387312 93.904742) (xy 149.381279 93.898125) (xy 149.381468 93.889685)
-				(xy 149.745432 93.008637) (xy 149.751757 93.002301) (xy 149.759098 93.00176)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "2e99c327-0d18-4ad8-8517-5a16ab0dab2b")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30060)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 112.125 93.95) (xy 112.125 94.2) (xy 112.648463 94.459776) (xy 113.001 94.075) (xy 112.648463 93.690224)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 112.654407 93.696712) (xy 112.993758 94.067096) (xy 112.99682 94.075511) (xy 112.993758 94.082904)
-				(xy 112.654407 94.453287) (xy 112.646291 94.457072) (xy 112.640579 94.455863) (xy 112.131499 94.203225)
-				(xy 112.125612 94.196478) (xy 112.125 94.192745) (xy 112.125 93.957254) (xy 112.128427 93.948981)
-				(xy 112.131495 93.946776) (xy 112.64058 93.694135) (xy 112.649513 93.693528)
-			)
-		)
-	)
-	(zone
-		(net 54)
-		(net_name "Net-(RN1C-R3.2)")
-		(layer "F.Cu")
-		(uuid "310a4548-9b91-42c1-a558-4d9afd8053b3")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30117)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 135.925 110.583579) (xy 135.783579 110.725) (xy 135.732612 110.886732) (xy 135.925707 111.638207)
-				(xy 136.067988 110.835765)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 135.930676 110.594448) (xy 135.932581 110.59695) (xy 136.06591 110.8321) (xy 136.067252 110.839914)
-				(xy 135.935128 111.58507) (xy 135.93031 111.592617) (xy 135.921565 111.594547) (xy 135.914018 111.589729)
-				(xy 135.912276 111.585939) (xy 135.733444 110.88997) (xy 135.733616 110.883543) (xy 135.782719 110.727727)
-				(xy 135.785602 110.722976) (xy 135.914131 110.594447) (xy 135.922403 110.591021)
-			)
-		)
-	)
-	(zone
-		(net 30)
-		(net_name "V_diode+")
-		(layer "F.Cu")
-		(uuid "33fa6c70-e812-4c66-8513-2cd6bc97965b")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30066)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 114.275 103.625) (xy 114.075 103.625) (xy 113.790224 104.148463) (xy 114.175 104.501) (xy 114.559776 104.148463)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 114.276318 103.628427) (xy 114.278323 103.631109) (xy 114.555403 104.140426) (xy 114.556346 104.149331)
-				(xy 114.553029 104.154644) (xy 114.182904 104.493758) (xy 114.174489 104.49682) (xy 114.167096 104.493758)
-				(xy 113.79697 104.154644) (xy 113.793185 104.146528) (xy 113.794596 104.140426) (xy 114.071677 103.631109)
-				(xy 114.078641 103.625479) (xy 114.081955 103.625) (xy 114.268045 103.625)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "3d6a9a94-6e03-4cca-8765-954f450eeb63")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30082)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 135.971235 92.175511) (xy 136.148011 91.998735) (xy 135.698973 91.77249) (xy 135.111793 92.049293)
-				(xy 135.682403 92.338582)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 135.704065 91.775056) (xy 136.13356 91.991454) (xy 136.139407 91.998237) (xy 136.138745 92.007167)
-				(xy 136.136569 92.010176) (xy 135.972364 92.174381) (xy 135.969843 92.176296) (xy 135.687858 92.335502)
-				(xy 135.678969 92.336586) (xy 135.676815 92.335749) (xy 135.362301 92.176296) (xy 135.133128 92.060109)
-				(xy 135.1273 92.053313) (xy 135.127985 92.044384) (xy 135.133429 92.039093) (xy 135.693814 91.774921)
-				(xy 135.702757 91.774494)
-			)
-		)
-	)
-	(zone
-		(net 13)
-		(net_name "Net-(J1-In)")
-		(layer "F.Cu")
-		(uuid "3ee82aff-83aa-44c8-86e6-21df7aeee772")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30071)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 144.092677 114.815901) (xy 143.915901 114.992677) (xy 143.690224 115.398463) (xy 144.075707 115.750707)
-				(xy 144.445619 115.377277)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 144.098851 114.826272) (xy 144.100483 114.828318) (xy 144.440675 115.369414) (xy 144.442177 115.378241)
-				(xy 144.439082 115.383875) (xy 144.083615 115.742723) (xy 144.075358 115.746189) (xy 144.067411 115.743126)
-				(xy 143.953046 115.638623) (xy 143.697051 115.404701) (xy 143.693256 115.396593) (xy 143.694718 115.390381)
-				(xy 143.915109 114.9941) (xy 143.917054 114.991523) (xy 144.082306 114.826271) (xy 144.090578 114.822845)
-			)
-		)
-	)
-	(zone
-		(net 7)
-		(net_name "Net-(RN1B-R2.2)")
-		(layer "F.Cu")
-		(uuid "3eee72fe-6873-4435-9781-f84af970f562")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30105)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 130.525 110.625) (xy 130.325 110.625) (xy 130.232612 110.886732) (xy 130.425 111.6385) (xy 130.617388 110.886732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 130.524995 110.628427) (xy 130.527755 110.632806) (xy 130.616204 110.88338) (xy 130.616506 110.890175)
-				(xy 130.436335 111.594207) (xy 130.430964 111.601372) (xy 130.422099 111.602641) (xy 130.414934 111.59727)
-				(xy 130.413665 111.594207) (xy 130.233493 110.890175) (xy 130.233795 110.88338) (xy 130.322245 110.632806)
-				(xy 130.32823 110.626145) (xy 130.333278 110.625) (xy 130.516722 110.625)
-			)
-		)
-	)
-	(zone
-		(net 46)
-		(net_name "Net-(RN1A-R1.1)")
-		(layer "F.Cu")
-		(uuid "4144edf4-7d33-44cb-9ea7-c120e45d2c6d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30112)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 135.151257 116.771967) (xy 135.328033 116.948743) (xy 135.447631 116.642837) (xy 135.275707 115.861793)
-				(xy 135.082612 116.613268)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 135.2849 115.90627) (xy 135.286254 115.909709) (xy 135.446867 116.639368) (xy 135.446338 116.646143)
-				(xy 135.334549 116.932076) (xy 135.328345 116.938534) (xy 135.319392 116.938713) (xy 135.315379 116.936089)
-				(xy 135.152835 116.773545) (xy 135.15037 116.769917) (xy 135.095402 116.642837) (xy 135.084201 116.616943)
-				(xy 135.083608 116.60939) (xy 135.263497 115.90931) (xy 135.268874 115.902152) (xy 135.27774 115.900892)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "43b15ac5-9bef-4eca-afdc-bd5ab0903b93")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30114)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 138.609616 114.35) (xy 138.609616 114.1) (xy 138.091473 114.255764) (xy 138.149 114.55) (xy 138.399441 114.716671)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 138.603457 114.105429) (xy 138.609121 114.112366) (xy 138.609616 114.115734) (xy 138.609616 114.346884)
-				(xy 138.608067 114.352702) (xy 138.405661 114.705819) (xy 138.398573 114.711293) (xy 138.389692 114.710152)
-				(xy 138.389028 114.709741) (xy 138.153064 114.552704) (xy 138.148075 114.545268) (xy 138.148063 114.545209)
-				(xy 138.110425 114.352702) (xy 138.093506 114.266162) (xy 138.095282 114.257386) (xy 138.10162 114.252713)
-				(xy 138.594549 114.104529)
-			)
-		)
-	)
-	(zone
-		(net 14)
-		(net_name "Relay-")
-		(layer "F.Cu")
-		(uuid "43fa501f-5ffc-4ef8-b917-2c316947b7f7")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30059)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 113.875 92.55) (xy 113.875 92.3) (xy 113.351537 92.040224) (xy 112.999 92.425) (xy 113.351537 92.809776)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 113.359419 92.044135) (xy 113.868502 92.296775) (xy 113.874388 92.303521) (xy 113.875 92.307254)
-				(xy 113.875 92.542745) (xy 113.871573 92.551018) (xy 113.868501 92.553225) (xy 113.35942 92.805863)
-				(xy 113.350486 92.806471) (xy 113.345592 92.803287) (xy 113.114459 92.551018) (xy 113.00624 92.432902)
-				(xy 113.003179 92.424489) (xy 113.00624 92.417097) (xy 113.345593 92.046711) (xy 113.353708 92.042927)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "440a23d3-3b40-4a3f-90bb-9a314d7e7c09")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30125)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 134.875 111.5125) (xy 134.875 111.7625) (xy 135.075 111.8375) (xy 135.276 111.6375) (xy 135.075 111.4375)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 135.076914 111.440441) (xy 135.080321 111.442794) (xy 135.267665 111.629206) (xy 135.271112 111.637471)
-				(xy 135.267706 111.645753) (xy 135.267664 111.645794) (xy 135.080325 111.832201) (xy 135.072044 111.835607)
-				(xy 135.067965 111.834862) (xy 134.882592 111.765347) (xy 134.876049 111.759233) (xy 134.875 111.754392)
-				(xy 134.875 111.520608) (xy 134.878427 111.512335) (xy 134.882592 111.509653) (xy 135.067967 111.440137)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "45027f0f-7a25-4106-b37a-75c628753372")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30025)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 140.525 91.675) (xy 140.525 91.925) (xy 141.179329 92.28097) (xy 141.751 91.8) (xy 141.179329 91.31903)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 141.185438 91.32417) (xy 141.740358 91.791047) (xy 141.744483 91.798996) (xy 141.741779 91.807532)
-				(xy 141.740358 91.808953) (xy 141.185438 92.275829) (xy 141.176902 92.278533) (xy 141.172315 92.277154)
-				(xy 140.531109 91.928323) (xy 140.525479 91.921359) (xy 140.525 91.918045) (xy 140.525 91.681954)
-				(xy 140.528427 91.673681) (xy 140.531106 91.671678) (xy 141.172316 91.322844) (xy 141.18122 91.321902)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "45e631d1-3fdc-4c45-839a-01f319073d9e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30078)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 132.505764 93.45) (xy 132.505764 93.95) (xy 133.041473 93.994236) (xy 133.101 93.7) (xy 133.041473 93.405764)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 133.101 93.7) (xy 133.041473 93.994236) (xy 132.505764 93.95) (xy 132.505764 93.45) (xy 133.041473 93.405764)
-			)
-		)
-	)
-	(zone
-		(net 30)
-		(net_name "V_diode+")
-		(layer "F.Cu")
-		(uuid "48fe595c-b7e1-4b8a-bd68-75bf5a6f0a5e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30018)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 121.608882 102.244696) (xy 121.750304 102.386118) (xy 122.716809 102.04251) (xy 122.590707 101.404293)
-				(xy 121.95249 101.278191)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 122.583016 101.402773) (xy 122.590468 101.407738) (xy 122.592226 101.411983) (xy 122.714851 102.032601)
-				(xy 122.713093 102.041382) (xy 122.707292 102.045893) (xy 121.757268 102.383641) (xy 121.748325 102.383183)
-				(xy 121.745076 102.38089) (xy 121.614109 102.249923) (xy 121.610682 102.24165) (xy 121.611358 102.237731)
-				(xy 121.949107 101.287705) (xy 121.955106 101.28106) (xy 121.962395 101.280148)
-			)
-		)
-	)
-	(zone
-		(net 2)
-		(net_name "Net-(J2-+5V)")
-		(layer "F.Cu")
-		(uuid "4a6b2fa5-dd11-444d-893c-b2c43e8286f3")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30056)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 125.274112 95.449112) (xy 125.450888 95.625888) (xy 125.840901 95.909099) (xy 126.225707 95.499293)
-				(xy 125.880996 95.064109)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 125.887537 95.072367) (xy 126.219438 95.491378) (xy 126.221889 95.499991) (xy 126.218796 95.506652)
-				(xy 125.84796 95.901581) (xy 125.839799 95.905266) (xy 125.832556 95.903039) (xy 125.451632 95.626428)
-				(xy 125.450234 95.625234) (xy 125.28444 95.45944) (xy 125.281013 95.451167) (xy 125.28444 95.442894)
-				(xy 125.286438 95.441291) (xy 125.872099 95.069752) (xy 125.880921 95.068215)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "4dff4c61-6122-4a09-a611-16bba1c766ff")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30047)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 140.484099 91.992677) (xy 140.307323 91.815901) (xy 139.836104 91.542127) (xy 139.499293 91.975707)
-				(xy 139.848972 92.399274)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 139.844947 91.547265) (xy 139.850006 91.550204) (xy 140.306009 91.815137) (xy 140.308402 91.81698)
-				(xy 140.473814 91.982392) (xy 140.477241 91.990665) (xy 140.473814 91.998938) (xy 140.471849 92.000519)
-				(xy 139.857703 92.393684) (xy 139.848888 92.395258) (xy 139.842372 92.391279) (xy 139.70408 92.223766)
-				(xy 139.505257 91.982932) (xy 139.502634 91.974371) (xy 139.505039 91.968309) (xy 139.82983 91.550203)
-				(xy 139.837611 91.545773)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "51d7b2d1-5d55-491e-a733-3301888ab9cf")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30110)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 110.1 94.0625) (xy 110.1 93.8125) (xy 109.8 93.6375) (xy 109.499 93.9375) (xy 109.8 94.2375)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 109.807775 93.642035) (xy 110.094196 93.809114) (xy 110.099615 93.816241) (xy 110.1 93.819219)
-				(xy 110.1 94.05578) (xy 110.096573 94.064053) (xy 110.094195 94.065886) (xy 109.807777 94.232963)
-				(xy 109.798904 94.234172) (xy 109.793623 94.231144) (xy 109.625975 94.064053) (xy 109.507313 93.945785)
-				(xy 109.503873 93.937519) (xy 109.507285 93.929241) (xy 109.793624 93.643854) (xy 109.801901 93.640442)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "537c385f-a84d-405d-a1cb-311fce7a210f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30079)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 125.218264 93.7125) (xy 125.218264 94.2125) (xy 125.753973 94.256736) (xy 125.8135 93.9625)
-				(xy 125.753973 93.668264)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 125.752131 93.671854) (xy 125.756035 93.67846) (xy 125.81303 93.96018) (xy 125.81303 93.96482)
-				(xy 125.756035 94.246539) (xy 125.751035 94.253968) (xy 125.743604 94.255879) (xy 125.229001 94.213386)
-				(xy 125.221038 94.20929) (xy 125.218264 94.201726) (xy 125.218264 93.723273) (xy 125.221691 93.715)
-				(xy 125.228999 93.711613) (xy 125.743604 93.66912)
-			)
-		)
-	)
-	(zone
-		(net 13)
-		(net_name "Net-(J1-In)")
-		(layer "F.Cu")
-		(uuid "54996c66-3d4b-4ced-8519-8fbc3160e668")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30005)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 149.494695 112.25) (xy 149.494695 112.75) (xy 150.930541 113.352256) (xy 151.501 112.5) (xy 150.930541 111.647744)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 150.935901 111.655753) (xy 151.496643 112.493492) (xy 151.498397 112.502273) (xy 151.496643 112.506508)
-				(xy 150.935901 113.344246) (xy 150.928451 113.349215) (xy 150.921652 113.348527) (xy 149.501869 112.753009)
-				(xy 149.495566 112.746649) (xy 149.494695 112.74222) (xy 149.494695 112.257779) (xy 149.498122 112.249506)
-				(xy 149.501865 112.246992) (xy 150.921653 111.651471) (xy 150.930607 111.651432)
-			)
-		)
-	)
-	(zone
-		(net 13)
-		(net_name "Net-(J1-In)")
-		(layer "F.Cu")
-		(uuid "55a4afc6-6ead-4997-a87d-80f197817571")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30013)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 145.95 114.25) (xy 145.95 113.75) (xy 145.295671 113.51903) (xy 143.749 114) (xy 145.295671 114.48097)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 145.299331 113.520322) (xy 145.942195 113.747244) (xy 145.948855 113.753229) (xy 145.95 113.758277)
-				(xy 145.95 114.241722) (xy 145.946573 114.249995) (xy 145.942194 114.252755) (xy 145.299331 114.479677)
-				(xy 145.291963 114.479816) (xy 143.784926 114.011172) (xy 143.778043 114.005443) (xy 143.777228 113.996526)
-				(xy 143.782957 113.989643) (xy 143.784926 113.988828) (xy 145.291963 113.520183)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "5879cfd1-2d24-41cf-b595-e10c70ca5c00")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30008)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 109.067762 105.640985) (xy 108.890985 105.817762) (xy 109.399215 107.32509) (xy 110.380707 107.130707)
-				(xy 110.57509 106.149215)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 109.074639 105.643304) (xy 109.516842 105.792402) (xy 110.565356 106.145933) (xy 110.5721 106.151823)
-				(xy 110.573094 106.159292) (xy 110.382228 107.123024) (xy 110.377259 107.130474) (xy 110.373024 107.132228)
-				(xy 109.409292 107.323094) (xy 109.400511 107.32134) (xy 109.395933 107.315356) (xy 108.893304 105.824639)
-				(xy 108.893908 105.815705) (xy 108.896115 105.812631) (xy 109.062629 105.646117) (xy 109.070901 105.642691)
-			)
-		)
-	)
-	(zone
-		(net 13)
-		(net_name "Net-(J1-In)")
-		(layer "F.Cu")
-		(uuid "58f96634-7a69-4fef-ad2b-f1827dfb8771")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30035)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 143.909099 114.985875) (xy 144.085875 114.809099) (xy 144.406389 114.5) (xy 143.749293 113.999293)
-				(xy 143.368913 114.5)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 143.758596 114.006381) (xy 144.395136 114.491425) (xy 144.395544 114.491736) (xy 144.400048 114.499476)
-				(xy 144.397759 114.508133) (xy 144.396575 114.509464) (xy 144.085855 114.809118) (xy 143.916945 114.978028)
-				(xy 143.908672 114.981455) (xy 143.900848 114.978454) (xy 143.900374 114.978028) (xy 143.376919 114.507201)
-				(xy 143.37306 114.499121) (xy 143.375427 114.491425) (xy 143.742206 114.008621) (xy 143.749939 114.004108)
-			)
-		)
-	)
-	(zone
-		(net 2)
-		(net_name "Net-(J2-+5V)")
-		(layer "F.Cu")
-		(uuid "59b00bc1-de57-455a-8bbf-535c3431f2ff")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30072)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 124.685615 96.377036) (xy 124.827036 96.235615) (xy 124.958349 95.839962) (xy 124.499293 95.536793)
-				(xy 124.180176 95.962354)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 124.508489 95.542866) (xy 124.950869 95.835022) (xy 124.955884 95.842441) (xy 124.955525 95.84847)
-				(xy 124.827908 96.232985) (xy 124.825077 96.237573) (xy 124.693112 96.369538) (xy 124.684839 96.372965)
-				(xy 124.677418 96.37031) (xy 124.396798 96.140079) (xy 124.188833 95.969456) (xy 124.184612 95.961561)
-				(xy 124.186893 95.953395) (xy 124.492682 95.545608) (xy 124.500385 95.541047)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "5bd47646-ffdd-4828-a353-c1ac3873abe2")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30076)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 138.35 92.175) (xy 138.35 91.925) (xy 137.957403 91.761418) (xy 137.3865 92.05) (xy 137.957403 92.338582)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 137.962368 91.763486) (xy 137.963233 91.763847) (xy 138.3428 91.922) (xy 138.349119 91.928345)
-				(xy 138.35 91.9328) (xy 138.35 92.167199) (xy 138.346573 92.175472) (xy 138.3428 92.177999) (xy 137.962374 92.33651)
-				(xy 137.953419 92.336529) (xy 137.952596 92.336152) (xy 137.407157 92.060442) (xy 137.401319 92.053651)
-				(xy 137.401993 92.044722) (xy 137.407157 92.039558) (xy 137.952597 91.763846) (xy 137.961525 91.763173)
-			)
-		)
-	)
-	(zone
-		(net 7)
-		(net_name "Net-(RN1B-R2.2)")
-		(layer "F.Cu")
-		(uuid "5cf60734-4a61-4b48-9746-25988a2b2200")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30104)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 130.3 112.65) (xy 130.55 112.65) (xy 130.617388 112.388268) (xy 130.425 111.6365) (xy 130.232612 112.388268)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 130.435066 111.677729) (xy 130.436335 111.680792) (xy 130.616643 112.385359) (xy 130.616638 112.391177)
-				(xy 130.552261 112.641217) (xy 130.54688 112.648375) (xy 130.540931 112.65) (xy 130.309069 112.65)
-				(xy 130.300796 112.646573) (xy 130.297739 112.641217) (xy 130.233361 112.391177) (xy 130.233356 112.385359)
-				(xy 130.413665 111.680792) (xy 130.419036 111.673627) (xy 130.427901 111.672358)
-			)
-		)
-	)
-	(zone
-		(net 54)
-		(net_name "Net-(RN1C-R3.2)")
-		(layer "F.Cu")
-		(uuid "5fdee43a-d6df-4942-9770-333c0fc5fe53")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30118)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 131.216421 110.725) (xy 131.075 110.583579) (xy 130.932012 110.835765) (xy 131.074293 111.638207)
-				(xy 131.267388 110.886732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.083367 110.592543) (xy 131.085869 110.594448) (xy 131.214395 110.722974) (xy 131.217281 110.72773)
-				(xy 131.266382 110.883541) (xy 131.266555 110.88997) (xy 131.087723 111.585939) (xy 131.082345 111.593099)
-				(xy 131.073479 111.594359) (xy 131.066319 111.588981) (xy 131.064871 111.58507) (xy 130.932747 110.839912)
-				(xy 130.934088 110.832102) (xy 131.067419 110.596948) (xy 131.07448 110.591444)
-			)
-		)
-	)
-	(zone
-		(net 10)
-		(net_name "Net-(U3-BYP)")
-		(layer "F.Cu")
-		(uuid "60c67a9a-5d3a-4c98-88a3-c960e25c27ca")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30108)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 141.7 105.4875) (xy 141.7 105.7375) (xy 142 105.9125) (xy 142.301 105.6125) (xy 142 105.3125)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 142.006376 105.318855) (xy 142.292685 105.604213) (xy 142.296126 105.612481) (xy 142.292713 105.620759)
-				(xy 142.292685 105.620787) (xy 142.006376 105.906144) (xy 141.998098 105.909557) (xy 141.992222 105.907963)
-				(xy 141.705805 105.740886) (xy 141.700385 105.733758) (xy 141.7 105.73078) (xy 141.7 105.494219)
-				(xy 141.703427 105.485946) (xy 141.7058 105.484116) (xy 141.992224 105.317035) (xy 142.001095 105.315827)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "621b51df-8181-450a-8c23-386b37593d07")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30010)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 95.25 99.4) (xy 94.75 99.4) (xy 94.21903 100.354329) (xy 95 101.001) (xy 95.78097 100.354329)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 95.251394 99.403427) (xy 95.253345 99.406012) (xy 95.776241 100.345831) (xy 95.777269 100.354726)
-				(xy 95.773479 100.360531) (xy 95.007462 100.994821) (xy 94.998904 100.997458) (xy 94.992538 100.994821)
-				(xy 94.22652 100.360531) (xy 94.222333 100.352615) (xy 94.223758 100.345831) (xy 94.746655 99.406012)
-				(xy 94.753672 99.400448) (xy 94.756879 99.4) (xy 95.243121 99.4)
-			)
-		)
-	)
-	(zone
-		(net 47)
-		(net_name "Net-(C6-Pad1)")
-		(layer "F.Cu")
-		(uuid "632d7c1d-b422-488b-9801-6833745c646f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30031)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 123.075 104.25) (xy 123.075 103.75) (xy 122.497887 103.55) (xy 122.174 104) (xy 122.497887 104.45)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 122.506122 103.552854) (xy 123.067132 103.747273) (xy 123.073826 103.753219) (xy 123.075 103.758327)
-				(xy 123.075 104.241672) (xy 123.071573 104.249945) (xy 123.067131 104.252727) (xy 122.506122 104.447145)
-				(xy 122.497183 104.446616) (xy 122.492795 104.442925) (xy 122.178919 104.006835) (xy 122.176867 103.998118)
-				(xy 122.178919 103.993165) (xy 122.492795 103.557073) (xy 122.500409 103.552361)
-			)
-		)
-	)
-	(zone
-		(net 47)
-		(net_name "Net-(C6-Pad1)")
-		(layer "F.Cu")
-		(uuid "661a2a61-a967-4714-90fc-a0197cd583e6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30048)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 123.175 103.75) (xy 123.175 104.25) (xy 123.622607 104.4) (xy 123.976 104) (xy 123.622607 103.6)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 123.624188 103.603084) (xy 123.62774 103.60581) (xy 123.969155 103.992253) (xy 123.972065 104.000722)
-				(xy 123.969155 104.007747) (xy 123.62774 104.394189) (xy 123.619694 104.39812) (xy 123.615254 104.397536)
-				(xy 123.605266 104.394189) (xy 123.570251 104.382454) (xy 123.182982 104.252674) (xy 123.176227 104.246796)
-				(xy 123.175 104.24158) (xy 123.175 103.758419) (xy 123.178427 103.750146) (xy 123.182982 103.747325)
-				(xy 123.615256 103.602463)
-			)
-		)
-	)
-	(zone
-		(net 31)
-		(net_name "V_diode-")
-		(layer "F.Cu")
-		(uuid "68aa4d77-fd49-4979-831e-e212381a9ad6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30017)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 119.703882 102.244696) (xy 119.845304 102.386118) (xy 120.811809 102.04251) (xy 120.685707 101.404293)
-				(xy 120.04749 101.278191)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 120.678016 101.402773) (xy 120.685468 101.407738) (xy 120.687226 101.411983) (xy 120.809851 102.032601)
-				(xy 120.808093 102.041382) (xy 120.802292 102.045893) (xy 120.090845 102.298824) (xy 120.086926 102.2995)
-				(xy 120.060435 102.2995) (xy 119.984012 102.319977) (xy 119.984008 102.319979) (xy 119.915488 102.359539)
-				(xy 119.914828 102.3602) (xy 119.910477 102.362947) (xy 119.852268 102.383641) (xy 119.843325 102.383183)
-				(xy 119.840076 102.38089) (xy 119.709109 102.249923) (xy 119.705682 102.24165) (xy 119.706358 102.237731)
-				(xy 120.044107 101.287705) (xy 120.050106 101.28106) (xy 120.057395 101.280148)
-			)
-		)
-	)
-	(zone
-		(net 54)
-		(net_name "Net-(RN1C-R3.2)")
-		(layer "F.Cu")
-		(uuid "6a468cf8-f0f3-4974-9f70-1a858192e617")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30100)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 131.6 112.65) (xy 131.85 112.65) (xy 131.917388 112.388268) (xy 131.725 111.6365) (xy 131.532612 112.388268)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.735066 111.677729) (xy 131.736335 111.680792) (xy 131.916643 112.385359) (xy 131.916638 112.391177)
-				(xy 131.852261 112.641217) (xy 131.84688 112.648375) (xy 131.840931 112.65) (xy 131.609069 112.65)
-				(xy 131.600796 112.646573) (xy 131.597739 112.641217) (xy 131.533361 112.391177) (xy 131.533356 112.385359)
-				(xy 131.713665 111.680792) (xy 131.719036 111.673627) (xy 131.727901 111.672358)
-			)
-		)
-	)
-	(zone
-		(net 44)
-		(net_name "Net-(RN1A-R1.2)")
-		(layer "F.Cu")
-		(uuid "6bb17909-c57a-4b45-94a6-d6d4baf1dbd0")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30097)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 129.9 110.625) (xy 129.65 110.625) (xy 129.582612 110.886732) (xy 129.775 111.6385) (xy 129.967388 110.886732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 129.899204 110.628427) (xy 129.902261 110.633783) (xy 129.966638 110.883822) (xy 129.966643 110.88964)
-				(xy 129.786335 111.594207) (xy 129.780964 111.601372) (xy 129.772099 111.602641) (xy 129.764934 111.59727)
-				(xy 129.763665 111.594207) (xy 129.583356 110.88964) (xy 129.583361 110.883822) (xy 129.647739 110.633783)
-				(xy 129.65312 110.626625) (xy 129.659069 110.625) (xy 129.890931 110.625)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "6bbbb425-1752-4a4a-be33-a8c01855303b")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30040)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 120.004809 96.381586) (xy 120.181586 96.204809) (xy 120.175 95.401368) (xy 119.724293 95.499293)
-				(xy 119.44395 95.963851)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 120.169745 95.406016) (xy 120.17485 95.413373) (xy 120.175117 95.415761) (xy 120.181545 96.199907)
-				(xy 120.178186 96.208208) (xy 120.01196 96.374434) (xy 120.003687 96.377861) (xy 119.996698 96.375544)
-				(xy 119.452462 95.970191) (xy 119.447874 95.962501) (xy 119.449434 95.954763) (xy 119.721688 95.503608)
-				(xy 119.728895 95.498297) (xy 119.729182 95.49823) (xy 120.160933 95.404424)
-			)
-		)
-	)
-	(zone
-		(net 36)
-		(net_name "-5V")
-		(layer "F.Cu")
-		(uuid "6bc00bc7-fc87-4393-be25-643b77c353cb")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30065)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 139.92552 115.651257) (xy 139.748743 115.47448) (xy 139.336104 115.342127) (xy 138.999293 115.775707)
-				(xy 139.427772 116.131152)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 139.343894 115.344625) (xy 139.746047 115.473615) (xy 139.750745 115.476482) (xy 139.917094 115.642831)
-				(xy 139.920521 115.651104) (xy 139.917094 115.659377) (xy 139.916942 115.659527) (xy 139.435307 116.123887)
-				(xy 139.426972 116.127162) (xy 139.419716 116.124469) (xy 139.008014 115.782941) (xy 139.003834 115.775021)
-				(xy 139.006243 115.766759) (xy 139.331085 115.348587) (xy 139.338865 115.344158)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "6ceff0be-bdc9-4839-92e5-4ca751817c7c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30081)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 126.409464 93.719089) (xy 126.055911 93.365536) (xy 125.645829 93.713059) (xy 125.811793 93.963207)
-				(xy 126.061941 94.129171)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 126.063529 93.373154) (xy 126.401845 93.71147) (xy 126.405272 93.719743) (xy 126.402498 93.727307)
-				(xy 126.068666 94.121234) (xy 126.060703 94.12533) (xy 126.053272 94.123419) (xy 125.813765 93.964515)
-				(xy 125.810484 93.961234) (xy 125.65158 93.721727) (xy 125.649861 93.712939) (xy 125.653764 93.706334)
-				(xy 126.047692 93.3725) (xy 126.056219 93.369767)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "Net-(C3-Pad2)")
-		(layer "F.Cu")
-		(uuid "6d178e92-cba3-4c67-8901-2563acb863c1")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30001)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 94.41066 113.292893) (xy 94.057107 112.93934) (xy 92.185786 113.75) (xy 92.599293 114.750707)
-				(xy 93.6 115.164214)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 94.062731 112.944964) (xy 94.405035 113.287268) (xy 94.408462 113.295541) (xy 94.407498 113.300192)
-				(xy 93.604572 115.153658) (xy 93.598139 115.159887) (xy 93.589368 115.15982) (xy 92.603782 114.752562)
-				(xy 92.597446 114.746238) (xy 92.190179 113.760631) (xy 92.190186 113.751676) (xy 92.19634 113.745427)
-				(xy 94.04981 112.9425) (xy 94.058761 112.942357)
-			)
-		)
-	)
-	(zone
-		(net 7)
-		(net_name "Net-(RN1B-R2.2)")
-		(layer "F.Cu")
-		(uuid "6d2489bb-fa9f-4d18-835e-ca786f5be814")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30074)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 132.850889 115.774113) (xy 132.674113 115.950889) (xy 133.080609 116.393696) (xy 133.500707 116.025707)
-				(xy 133.163896 115.592127)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 133.170172 115.600206) (xy 133.49394 116.016996) (xy 133.496309 116.025632) (xy 133.492409 116.032975)
-				(xy 133.089206 116.386164) (xy 133.080725 116.389038) (xy 133.072878 116.385275) (xy 132.681692 115.959145)
-				(xy 132.678623 115.950735) (xy 132.682038 115.942963) (xy 132.849814 115.775187) (xy 132.852198 115.773351)
-				(xy 133.155052 115.597268) (xy 133.163926 115.596074)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "6de62e65-d1fe-48aa-a1ea-f053d7c2f7db")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30026)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 142.975 91.925) (xy 142.975 91.675) (xy 142.320671 91.31903) (xy 141.749 91.8) (xy 142.320671 92.28097)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 142.327683 91.322844) (xy 142.968891 91.671677) (xy 142.974521 91.67864) (xy 142.975 91.681954)
-				(xy 142.975 91.918045) (xy 142.971573 91.926318) (xy 142.968891 91.928323) (xy 142.327684 92.277154)
-				(xy 142.318779 92.278097) (xy 142.314561 92.275829) (xy 141.759641 91.808953) (xy 141.755516 91.801004)
-				(xy 141.75822 91.792468) (xy 141.759641 91.791047) (xy 141.901523 91.671676) (xy 142.314562 91.324169)
-				(xy 142.323097 91.321466)
-			)
-		)
-	)
-	(zone
-		(net 1)
-		(net_name "Net-(C3-Pad2)")
-		(layer "F.Cu")
-		(uuid "6e6e9ee0-9c5c-4288-9560-d67f95ec84ec")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30009)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 94.75 104.584628) (xy 95.25 104.584628) (xy 95.784628 103.156072) (xy 95 102.999) (xy 94.215372 103.156072)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 95.771149 103.153373) (xy 95.778587 103.158357) (xy 95.780323 103.167142) (xy 95.779809 103.168946)
-				(xy 95.252844 104.577029) (xy 95.246735 104.583576) (xy 95.241886 104.584628) (xy 94.758114 104.584628)
-				(xy 94.749841 104.581201) (xy 94.747156 104.577029) (xy 94.22019 103.168946) (xy 94.2205 103.159996)
-				(xy 94.227047 103.153887) (xy 94.228842 103.153375) (xy 94.997707 102.999459) (xy 95.002293 102.999459)
-			)
-		)
-	)
-	(zone
-		(net 14)
-		(net_name "Relay-")
-		(layer "F.Cu")
-		(uuid "6edc4711-da8a-42b3-b755-47b6c52cc96d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30015)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 119.574482 99.197705) (xy 119.397705 99.374482) (xy 120.323879 100.040455) (xy 120.685707 99.500707)
-				(xy 120.558191 98.86249)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 120.554494 98.86737) (xy 120.560407 98.874095) (xy 120.560805 98.875577) (xy 120.684754 99.495939)
-				(xy 120.683015 99.504723) (xy 120.682999 99.504746) (xy 120.33061 100.030412) (xy 120.323157 100.035376)
-				(xy 120.314377 100.033615) (xy 120.314062 100.033396) (xy 119.408882 99.382519) (xy 119.404165 99.374907)
-				(xy 119.406213 99.36619) (xy 119.407433 99.364753) (xy 119.572559 99.199627) (xy 119.577052 99.196828)
-				(xy 120.54556 98.866794)
-			)
-		)
-	)
-	(zone
-		(net 9)
-		(net_name "Net-(U2-BYP)")
-		(layer "F.Cu")
-		(uuid "6efccd56-3fe8-4c45-96f6-30fe1d08649f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30086)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 138.409099 93.967677) (xy 138.232323 93.790901) (xy 137.957403 93.661418) (xy 137.386793 93.950707)
-				(xy 138.007361 94.204127)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 137.96257 93.663851) (xy 137.962894 93.664004) (xy 138.230478 93.790032) (xy 138.233766 93.792344)
-				(xy 138.39841 93.956988) (xy 138.401837 93.965261) (xy 138.39841 93.973534) (xy 138.396072 93.975344)
-				(xy 138.012355 94.201187) (xy 138.003487 94.20243) (xy 138.001997 94.201936) (xy 137.410507 93.960391)
-				(xy 137.404143 93.95409) (xy 137.404098 93.945136) (xy 137.409638 93.939124) (xy 137.952302 93.664003)
-				(xy 137.961229 93.663319)
-			)
-		)
-	)
-	(zone
-		(net 14)
-		(net_name "Relay-")
-		(layer "F.Cu")
-		(uuid "7159b302-cfa5-498d-829d-32ab0dd90d7a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30122)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 116.05 93.925) (xy 116.05 94.175) (xy 116.28246 94.275) (xy 116.501 94.05) (xy 116.28246 93.825)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 116.288074 93.83078) (xy 116.493082 94.041848) (xy 116.496388 94.05017) (xy 116.493082 94.058152)
-				(xy 116.288074 94.269219) (xy 116.279851 94.272766) (xy 116.275058 94.271815) (xy 116.057077 94.178044)
-				(xy 116.050831 94.171627) (xy 116.05 94.167296) (xy 116.05 93.932703) (xy 116.053427 93.92443) (xy 116.057074 93.921956)
-				(xy 116.275058 93.828183) (xy 116.284012 93.828063)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "72dde9cd-ff4b-4b4e-bb5c-49a39c53e6ec")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30062)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 134.15 91.8) (xy 134.15 92.3) (xy 134.6 92.35) (xy 135.1135 92.05) (xy 134.6 91.75)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 134.603342 91.751952) (xy 134.899062 91.92472) (xy 135.096208 92.039898) (xy 135.101623 92.04703)
-				(xy 135.100408 92.055902) (xy 135.096208 92.060102) (xy 134.603344 92.348046) (xy 134.59615 92.349572)
-				(xy 134.160408 92.301156) (xy 134.152564 92.296837) (xy 134.15 92.289528) (xy 134.15 91.810471)
-				(xy 134.153427 91.802198) (xy 134.160406 91.798843) (xy 134.596152 91.750427)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "78049aa2-a086-49aa-b2fe-88005df40ed9")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30089)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 120.875 105.561094) (xy 120.375 105.561094) (xy 120.750559 106.166671) (xy 121 106.001) (xy 121.166671 105.750559)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 121.166671 105.750559) (xy 121 106.001) (xy 120.750559 106.166671) (xy 120.375 105.561094) (xy 120.875 105.561094)
-			)
-		)
-	)
-	(zone
-		(net 4)
-		(net_name "LD_short-")
-		(layer "F.Cu")
-		(uuid "787e34e7-92c4-4ce7-bc19-28bf06b1dc4f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30002)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 101.062584 116.669691) (xy 101.769691 115.962584) (xy 101.200785 114.55491) (xy 100.219293 114.749293)
-				(xy 99.66443 115.58147)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 101.200071 114.558544) (xy 101.204411 114.563883) (xy 101.766789 115.955403) (xy 101.766711 115.964357)
-				(xy 101.764214 115.96806) (xy 101.069889 116.662385) (xy 101.061616 116.665812) (xy 101.054431 116.663345)
-				(xy 99.67301 115.588148) (xy 99.668586 115.580362) (xy 99.67046 115.572425) (xy 100.216599 114.753333)
-				(xy 100.224036 114.748353) (xy 101.191291 114.55679)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "797ddc51-b2fe-4719-8441-b75b6a449237")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30021)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 133.225 92.05) (xy 133.225 91.55) (xy 132.570671 91.31903) (xy 131.999 91.8) (xy 132.570671 92.28097)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 132.576975 91.321255) (xy 133.217195 91.547244) (xy 133.223855 91.553229) (xy 133.225 91.558277)
-				(xy 133.225 92.041722) (xy 133.221573 92.049995) (xy 133.217194 92.052755) (xy 132.576978 92.278743)
-				(xy 132.568036 92.278265) (xy 132.565552 92.276663) (xy 132.009641 91.808953) (xy 132.005516 91.801004)
-				(xy 132.00822 91.792468) (xy 132.009641 91.791047) (xy 132.565553 91.323335) (xy 132.574088 91.320632)
-			)
-		)
-	)
-	(zone
-		(net 11)
-		(net_name "Net-(D2-A)")
-		(layer "F.Cu")
-		(uuid "79924ebc-35f8-4731-86dd-f1a8d8eaff65")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30090)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 107.95 91.8125) (xy 107.95 92.3125) (xy 108.25 92.3625) (xy 108.551 92.0625) (xy 108.25 91.7625)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 108.252796 91.765507) (xy 108.254255 91.766741) (xy 108.542685 92.054213) (xy 108.546126 92.062481)
-				(xy 108.542713 92.070759) (xy 108.542685 92.070787) (xy 108.254255 92.358258) (xy 108.245977 92.361671)
-				(xy 108.244073 92.361512) (xy 107.959777 92.314129) (xy 107.952179 92.309388) (xy 107.95 92.302588)
-				(xy 107.95 91.822411) (xy 107.953427 91.814138) (xy 107.959775 91.81087) (xy 108.244075 91.763487)
-			)
-		)
-	)
-	(zone
-		(net 36)
-		(net_name "-5V")
-		(layer "F.Cu")
-		(uuid "7fa0f0c9-3c06-46f8-ba2e-0d1ff7892513")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30038)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 138.075 115.65) (xy 138.075 115.9) (xy 138.663896 116.207873) (xy 139.001 115.775) (xy 138.663896 115.342127)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 138.669895 115.34983) (xy 138.995401 115.767811) (xy 138.997781 115.776444) (xy 138.995401 115.782189)
-				(xy 138.669895 116.200169) (xy 138.662108 116.204591) (xy 138.655243 116.203349) (xy 138.081279 115.903282)
-				(xy 138.075535 115.896412) (xy 138.075 115.892913) (xy 138.075 115.657086) (xy 138.078427 115.648813)
-				(xy 138.081277 115.646718) (xy 138.655244 115.346649) (xy 138.664163 115.345854)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "80d458c3-366a-40a5-8d08-77bc2af94621")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30073)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 111.625 103.15) (xy 111.375 103.15) (xy 111.211418 103.542597) (xy 111.5 104.1885) (xy 111.788582 103.542597)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 111.625473 103.153427) (xy 111.628 103.1572) (xy 111.786639 103.537935) (xy 111.786658 103.54689)
-				(xy 111.786521 103.547208) (xy 111.510682 104.164591) (xy 111.504179 104.170746) (xy 111.495227 104.1705)
-				(xy 111.489318 104.164591) (xy 111.213478 103.547208) (xy 111.213232 103.538256) (xy 111.21336 103.537935)
-				(xy 111.372 103.1572) (xy 111.378345 103.150881) (xy 111.3828 103.15) (xy 111.6172 103.15)
-			)
-		)
-	)
-	(zone
-		(net 4)
-		(net_name "LD_short-")
-		(layer "F.Cu")
-		(uuid "82e05eb6-6ec1-48d7-b6c7-ae97bbbe1743")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30061)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 117.05 105.375) (xy 117.3 105.375) (xy 117.559776 104.851537) (xy 117.175 104.499) (xy 116.790224 104.851537)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 117.182902 104.50624) (xy 117.445197 104.746558) (xy 117.553287 104.845592) (xy 117.557072 104.853708)
-				(xy 117.555863 104.85942) (xy 117.303225 105.368501) (xy 117.296478 105.374388) (xy 117.292745 105.375)
-				(xy 117.057255 105.375) (xy 117.048982 105.371573) (xy 117.046775 105.368501) (xy 116.794136 104.85942)
-				(xy 116.793528 104.850486) (xy 116.796711 104.845593) (xy 117.167097 104.50624) (xy 117.175511 104.503179)
-			)
-		)
-	)
-	(zone
-		(net 8)
-		(net_name "Net-(U1A-+)")
-		(layer "F.Cu")
-		(uuid "83340757-66b4-4799-a9c1-d58fb562a704")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30069)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 141.625 115.625) (xy 141.625 115.875) (xy 142.072607 116.15) (xy 142.426 115.75) (xy 142.072607 115.35)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 142.079119 115.357371) (xy 142.419155 115.742253) (xy 142.422065 115.750722) (xy 142.419155 115.757747)
-				(xy 142.079119 116.142628) (xy 142.071073 116.146559) (xy 142.064226 116.14485) (xy 141.630575 115.878425)
-				(xy 141.62532 115.871174) (xy 141.625 115.868456) (xy 141.625 115.631543) (xy 141.628427 115.62327)
-				(xy 141.63057 115.621577) (xy 142.064226 115.355148) (xy 142.073069 115.353738)
-			)
-		)
-	)
-	(zone
-		(net 39)
-		(net_name "-12V")
-		(layer "F.Cu")
-		(uuid "84ce6158-98b8-4578-989d-6d0d5a0018fa")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30087)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 143.267677 104.590901) (xy 143.090901 104.767677) (xy 142.961418 105.042597) (xy 143.250707 105.613207)
-				(xy 143.504127 104.992638)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 143.273534 104.601589) (xy 143.275344 104.603927) (xy 143.501187 104.987643) (xy 143.50243 104.996511)
-				(xy 143.501936 104.998001) (xy 143.260391 105.589492) (xy 143.25409 105.595856) (xy 143.245136 105.595901)
-				(xy 143.239124 105.59036) (xy 143.231474 105.575272) (xy 142.964003 105.047697) (xy 142.963319 105.03877)
-				(xy 142.963849 105.037434) (xy 143.090033 104.769518) (xy 143.092341 104.766236) (xy 143.256989 104.601588)
-				(xy 143.265261 104.598162)
-			)
-		)
-	)
-	(zone
-		(net 39)
-		(net_name "-12V")
-		(layer "F.Cu")
-		(uuid "85522905-e10e-4019-95e8-ecdc9757eaf3")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30037)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 142.411611 104.588387) (xy 142.588387 104.411611) (xy 142.78097 104.070671) (xy 142.299293 103.499293)
-				(xy 141.92747 104.188023)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 142.306982 103.509677) (xy 142.310367 103.512429) (xy 142.766628 104.053659) (xy 142.775729 104.064454)
-				(xy 142.778442 104.072988) (xy 142.776971 104.077749) (xy 142.589172 104.41022) (xy 142.587258 104.412739)
-				(xy 142.419137 104.58086) (xy 142.410864 104.584287) (xy 142.403408 104.581603) (xy 141.934872 104.194144)
-				(xy 141.93068 104.186231) (xy 141.932032 104.179571) (xy 142.29113 103.514413) (xy 142.298074 103.508762)
-			)
-		)
-	)
-	(zone
-		(net 41)
-		(net_name "Curr_Mod")
-		(layer "F.Cu")
-		(uuid "867322f8-8dac-4d0b-92c1-0f66912bd86e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30058)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 115.7 105.375) (xy 115.95 105.375) (xy 116.209776 104.851537) (xy 115.825 104.499) (xy 115.440224 104.851537)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 115.832902 104.50624) (xy 116.095197 104.746558) (xy 116.203287 104.845592) (xy 116.207072 104.853708)
-				(xy 116.205863 104.85942) (xy 115.953225 105.368501) (xy 115.946478 105.374388) (xy 115.942745 105.375)
-				(xy 115.707255 105.375) (xy 115.698982 105.371573) (xy 115.696775 105.368501) (xy 115.444136 104.85942)
-				(xy 115.443528 104.850486) (xy 115.446711 104.845593) (xy 115.817097 104.50624) (xy 115.825511 104.503179)
-			)
-		)
-	)
-	(zone
-		(net 12)
-		(net_name "Net-(D4-A)")
-		(layer "F.Cu")
-		(uuid "885bf08b-dc79-4709-8b9a-c1afed4e4edc")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30050)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 102.75 101.625) (xy 102.25 101.625) (xy 102.1 102.072606) (xy 102.5 102.426) (xy 102.9 102.072606)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 102.749854 101.628427) (xy 102.752675 101.632982) (xy 102.897536 102.065253) (xy 102.896915 102.074187)
-				(xy 102.894189 102.077739) (xy 102.507747 102.419155) (xy 102.499278 102.422065) (xy 102.492253 102.419155)
-				(xy 102.10581 102.077739) (xy 102.101879 102.069693) (xy 102.102462 102.065258) (xy 102.247325 101.632981)
-				(xy 102.253203 101.626227) (xy 102.258419 101.625) (xy 102.741581 101.625)
-			)
-		)
-	)
-	(zone
-		(net 54)
-		(net_name "Net-(RN1C-R3.2)")
-		(layer "F.Cu")
-		(uuid "8c4da72b-74d2-4658-a421-f37352a487de")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30064)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 132.780546 114.103769) (xy 132.603769 114.280546) (xy 133.04706 114.793487) (xy 133.500707 114.475707)
-				(xy 133.25 114.025)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 133.25058 114.028377) (xy 133.254015 114.032218) (xy 133.495579 114.466489) (xy 133.496606 114.475384)
-				(xy 133.492067 114.481759) (xy 133.055714 114.787424) (xy 133.046972 114.789364) (xy 133.04015 114.785491)
-				(xy 132.764464 114.466489) (xy 132.610882 114.288776) (xy 132.608065 114.280276) (xy 132.61146 114.272854)
-				(xy 132.777901 114.106413) (xy 132.784233 114.10315) (xy 133.241856 114.026366)
-			)
-		)
-	)
-	(zone
-		(net 31)
-		(net_name "V_diode-")
-		(layer "F.Cu")
-		(uuid "90ec1e4e-9633-41d9-a63e-f416a6016c79")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30067)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 118.925 103.625) (xy 118.725 103.625) (xy 118.440224 104.148463) (xy 118.825 104.501) (xy 119.209776 104.148463)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 118.926318 103.628427) (xy 118.928323 103.631109) (xy 119.205403 104.140426) (xy 119.206346 104.149331)
-				(xy 119.203029 104.154644) (xy 118.832904 104.493758) (xy 118.824489 104.49682) (xy 118.817096 104.493758)
-				(xy 118.44697 104.154644) (xy 118.443185 104.146528) (xy 118.444596 104.140426) (xy 118.721677 103.631109)
-				(xy 118.728641 103.625479) (xy 118.731955 103.625) (xy 118.918045 103.625)
-			)
-		)
-	)
-	(zone
-		(net 39)
-		(net_name "-12V")
-		(layer "F.Cu")
-		(uuid "95a91749-2eae-4364-8ac3-8a5f24d1f578")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30033)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 142.724264 102.502513) (xy 142.547487 102.325736) (xy 141.99741 102.78546) (xy 142.299293 103.500707)
-				(xy 142.8 103.025)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 142.555053 102.333302) (xy 142.721515 102.499764) (xy 142.724821 102.506359) (xy 142.799131 103.019009)
-				(xy 142.796926 103.027688) (xy 142.795611 103.029169) (xy 142.311554 103.489057) (xy 142.303196 103.492271)
-				(xy 142.295013 103.488634) (xy 142.292716 103.485125) (xy 142.000775 102.793434) (xy 142.000716 102.784481)
-				(xy 142.00405 102.77991) (xy 142.539277 102.332596) (xy 142.547823 102.329922)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "9d4feb95-d23f-45f0-9a01-6a61ef5fa015")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30032)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 120.375 104.925) (xy 120.875 104.925) (xy 121.057873 104.336104) (xy 120.625 103.999) (xy 120.192127 104.336104)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 120.632187 104.004597) (xy 120.950857 104.252764) (xy 121.051487 104.331131) (xy 121.055909 104.338918)
-				(xy 121.055472 104.343832) (xy 120.877556 104.91677) (xy 120.871829 104.923654) (xy 120.866382 104.925)
-				(xy 120.383618 104.925) (xy 120.375345 104.921573) (xy 120.372444 104.91677) (xy 120.194527 104.343832)
-				(xy 120.195347 104.334915) (xy 120.19851 104.331132) (xy 120.617811 104.004597) (xy 120.626444 104.002218)
-			)
-		)
-	)
-	(zone
-		(net 53)
-		(net_name "Net-(K1-Pad21)")
-		(layer "F.Cu")
-		(uuid "a2f930bc-3ab0-4d8b-8aa2-2a822f2e74be")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30049)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 102.25 104.875) (xy 102.75 104.875) (xy 102.9 104.427393) (xy 102.5 104.074) (xy 102.1 104.427393)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 102.507747 104.080844) (xy 102.894189 104.422259) (xy 102.89812 104.430305) (xy 102.897536 104.434745)
-				(xy 102.752675 104.867018) (xy 102.746797 104.873773) (xy 102.741581 104.875) (xy 102.258419 104.875)
-				(xy 102.250146 104.871573) (xy 102.247325 104.867018) (xy 102.102463 104.434743) (xy 102.103084 104.425811)
-				(xy 102.105807 104.422262) (xy 102.492253 104.080843) (xy 102.500722 104.077934)
-			)
-		)
-	)
-	(zone
-		(net 44)
-		(net_name "Net-(RN1A-R1.2)")
-		(layer "F.Cu")
-		(uuid "a6876f9c-1bd9-4721-9797-a3c15449ff8f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30106)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 137.325 110.625) (xy 137.125 110.625) (xy 137.032612 110.886732) (xy 137.225 111.6385) (xy 137.417388 110.886732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 137.324995 110.628427) (xy 137.327755 110.632806) (xy 137.416204 110.88338) (xy 137.416506 110.890175)
-				(xy 137.236335 111.594207) (xy 137.230964 111.601372) (xy 137.222099 111.602641) (xy 137.214934 111.59727)
-				(xy 137.213665 111.594207) (xy 137.033493 110.890175) (xy 137.033795 110.88338) (xy 137.122245 110.632806)
-				(xy 137.12823 110.626145) (xy 137.133278 110.625) (xy 137.316722 110.625)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "aae9174f-266e-4225-a37b-dcf002801708")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30083)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 136.148011 94.001265) (xy 135.971235 93.824489) (xy 135.682403 93.661418) (xy 135.111793 93.950707)
-				(xy 135.698973 94.227509)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 135.687851 93.664494) (xy 135.969843 93.823703) (xy 135.972364 93.825618) (xy 136.136569 93.989823)
-				(xy 136.139996 93.998096) (xy 136.136569 94.006369) (xy 136.13356 94.008545) (xy 135.704066 94.224942)
-				(xy 135.695136 94.225604) (xy 135.693813 94.225076) (xy 135.133431 93.960907) (xy 135.127409 93.95428)
-				(xy 135.127837 93.945335) (xy 135.133127 93.939891) (xy 135.676817 93.664249) (xy 135.685744 93.663565)
-			)
-		)
-	)
-	(zone
-		(net 21)
-		(net_name "Net-(J2-DDCIO)")
-		(layer "F.Cu")
-		(uuid "acc2e910-255f-4e18-9e2c-ccd8d380ed65")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30075)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 112.55 101.275) (xy 112.35 101.275) (xy 112.161418 101.667597) (xy 112.45 102.3135) (xy 112.738582 101.667597)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 112.550914 101.278427) (xy 112.553187 101.281634) (xy 112.736234 101.662708) (xy 112.736728 101.671649)
-				(xy 112.73637 101.672547) (xy 112.460682 102.289591) (xy 112.454179 102.295746) (xy 112.445227 102.2955)
-				(xy 112.439318 102.289591) (xy 112.355123 102.101148) (xy 112.163628 101.672545) (xy 112.163383 101.663595)
-				(xy 112.163752 101.662736) (xy 112.346813 101.281633) (xy 112.353484 101.27566) (xy 112.357359 101.275)
-				(xy 112.542641 101.275)
-			)
-		)
-	)
-	(zone
-		(net 2)
-		(net_name "Net-(J2-+5V)")
-		(layer "F.Cu")
-		(uuid "afabb1a4-8e09-4c94-8c6e-6f2bf078565c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30053)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 125.486243 95.590533) (xy 125.309467 95.413757) (xy 124.839962 95.116651) (xy 124.499293 95.538207)
-				(xy 124.839962 95.958349)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 124.848767 95.122223) (xy 125.308369 95.413062) (xy 125.310386 95.414676) (xy 125.475391 95.579681)
-				(xy 125.478818 95.587954) (xy 125.475391 95.596227) (xy 125.472905 95.598123) (xy 124.848586 95.95344)
-				(xy 124.839701 95.954553) (xy 124.833711 95.95064) (xy 124.541721 95.590533) (xy 124.505256 95.545561)
-				(xy 124.502708 95.536978) (xy 124.505243 95.530843) (xy 124.833413 95.124754) (xy 124.841276 95.120475)
-			)
-		)
-	)
-	(zone
-		(net 4)
-		(net_name "LD_short-")
-		(layer "F.Cu")
-		(uuid "b0470671-a7c6-4551-b3b9-96c9c46766b0")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30027)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 121.9 111.625) (xy 121.9 111.875) (xy 122.4 112.25) (xy 123.001 111.75) (xy 122.4 111.25)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 122.407105 111.255911) (xy 122.846531 111.62149) (xy 122.990189 111.741006) (xy 122.994357 111.748931)
-				(xy 122.9917 111.757483) (xy 122.990189 111.758994) (xy 122.407107 112.244087) (xy 122.398555 112.246744)
-				(xy 122.392604 112.244453) (xy 121.90468 111.87851) (xy 121.900118 111.870805) (xy 121.9 111.86915)
-				(xy 121.9 111.63085) (xy 121.903427 111.622577) (xy 121.90468 111.62149) (xy 122.392606 111.255545)
-				(xy 122.401279 111.253324)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "b06ea98b-d759-4cc4-81c0-989a4d6e1ffb")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30028)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 94.85 94.45) (xy 94.35 94.45) (xy 94.167127 95.038896) (xy 94.6 95.501) (xy 95.032873 95.038896)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 94.849655 94.453427) (xy 94.852556 94.45823) (xy 95.030854 95.032395) (xy 95.030034 95.041312)
-				(xy 95.028219 95.043864) (xy 94.608539 95.491884) (xy 94.600382 95.495579) (xy 94.592001 95.492424)
-				(xy 94.591461 95.491884) (xy 94.455628 95.346879) (xy 94.171779 95.043862) (xy 94.168625 95.035483)
-				(xy 94.169144 95.0324) (xy 94.347444 94.458229) (xy 94.353171 94.451346) (xy 94.358618 94.45) (xy 94.841382 94.45)
-			)
-		)
-	)
-	(zone
-		(net 53)
-		(net_name "Net-(K1-Pad21)")
-		(layer "F.Cu")
-		(uuid "b2f76064-fe07-4a1f-a2b2-bf13ac27d3c9")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30007)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 102.280677 107.072877) (xy 101.927123 106.719323) (xy 100.41509 106.149215) (xy 100.219293 107.130707)
-				(xy 100.77557 107.96147)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 100.427989 106.154078) (xy 101.924763 106.718433) (xy 101.928908 106.721108) (xy 102.270003 107.062203)
-				(xy 102.27343 107.070476) (xy 102.270003 107.078749) (xy 102.267678 107.080551) (xy 100.785089 107.955849)
-				(xy 100.776223 107.957104) (xy 100.769419 107.952284) (xy 100.221995 107.134742) (xy 100.22024 107.125961)
-				(xy 100.220243 107.125943) (xy 100.229299 107.080551) (xy 100.412392 106.162738) (xy 100.417371 106.155296)
-				(xy 100.426155 106.153554)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "Net-(J2-DDCCL)")
-		(layer "F.Cu")
-		(uuid "b59a2a60-aa7f-480f-bf48-9142f1dca302")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30070)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 123.132582 96.409359) (xy 123.309359 96.232582) (xy 123.458349 95.839962) (xy 122.999293 95.536793)
-				(xy 122.664041 95.959145)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 123.008239 95.542701) (xy 123.450536 95.834802) (xy 123.455551 95.842221) (xy 123.455027 95.848716)
-				(xy 123.310249 96.230235) (xy 123.307583 96.234357) (xy 123.140692 96.401248) (xy 123.132419 96.404675)
-				(xy 123.124312 96.401412) (xy 122.671715 95.966519) (xy 122.668124 95.958315) (xy 122.670657 95.950809)
-				(xy 122.992628 95.545189) (xy 123.000455 95.540841)
-			)
-		)
-	)
-	(zone
-		(net 11)
-		(net_name "Net-(D2-A)")
-		(layer "F.Cu")
-		(uuid "b965fd4b-86cf-4323-ab16-01bc571da03d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30109)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 109.15 92.1875) (xy 109.15 91.9375) (xy 108.85 91.7625) (xy 108.549 92.0625) (xy 108.85 92.3625)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 108.857775 91.767035) (xy 109.144196 91.934114) (xy 109.149615 91.941241) (xy 109.15 91.944219)
-				(xy 109.15 92.18078) (xy 109.146573 92.189053) (xy 109.144195 92.190886) (xy 108.857777 92.357963)
-				(xy 108.848904 92.359172) (xy 108.843623 92.356144) (xy 108.675975 92.189053) (xy 108.557313 92.070785)
-				(xy 108.553873 92.062519) (xy 108.557285 92.054241) (xy 108.843624 91.768854) (xy 108.851901 91.765442)
-			)
-		)
-	)
-	(zone
-		(net 54)
-		(net_name "Net-(RN1C-R3.2)")
-		(layer "F.Cu")
-		(uuid "bd476d51-b218-4c95-b82b-10095998493a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30119)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 131.901776 110.739645) (xy 131.760355 110.598224) (xy 131.612388 110.827508) (xy 131.724293 111.638207)
-				(xy 131.925 110.925)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.768672 110.606912) (xy 131.770601 110.60847) (xy 131.898938 110.736807) (xy 131.902274 110.743625)
-				(xy 131.924705 110.922651) (xy 131.924359 110.927275) (xy 131.73948 111.58424) (xy 131.73394 111.591276)
-				(xy 131.725048 111.592334) (xy 131.718012 111.586794) (xy 131.716627 111.582671) (xy 131.612981 110.831806)
-				(xy 131.614739 110.823864) (xy 131.752498 110.610397) (xy 131.759863 110.605306)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "bea2668e-962b-4a42-ab4c-f0a0f982afe4")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30099)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 130.55 114.85) (xy 130.3 114.85) (xy 130.232612 115.111732) (xy 130.425 115.8635) (xy 130.617388 115.111732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 130.549204 114.853427) (xy 130.552261 114.858783) (xy 130.616638 115.108822) (xy 130.616643 115.11464)
-				(xy 130.436335 115.819207) (xy 130.430964 115.826372) (xy 130.422099 115.827641) (xy 130.414934 115.82227)
-				(xy 130.413665 115.819207) (xy 130.233356 115.11464) (xy 130.233361 115.108822) (xy 130.297739 114.858783)
-				(xy 130.30312 114.851625) (xy 130.309069 114.85) (xy 130.540931 114.85)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "c50f6701-a18a-48f1-a6ed-db07ba262b7f")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30039)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 134.425 111.6) (xy 134.425 111.35) (xy 133.836104 111.042127) (xy 133.499 111.475) (xy 133.836104 111.907873)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 133.844755 111.046649) (xy 134.418721 111.346717) (xy 134.424465 111.353587) (xy 134.425 111.357086)
-				(xy 134.425 111.592913) (xy 134.421573 111.601186) (xy 134.418721 111.603282) (xy 133.844756 111.903349)
-				(xy 133.835836 111.904145) (xy 133.830104 111.900169) (xy 133.504597 111.482188) (xy 133.502218 111.473556)
-				(xy 133.504597 111.467812) (xy 133.830106 111.049828) (xy 133.837891 111.045408)
-			)
-		)
-	)
-	(zone
-		(net 44)
-		(net_name "Net-(RN1A-R1.2)")
-		(layer "F.Cu")
-		(uuid "c5827437-b352-4256-927c-9c9733a070d6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30044)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 131.783594 109.550015) (xy 131.925015 109.408594) (xy 131.675 108.734314) (xy 131.199293 108.824293)
-				(xy 131.034314 109.225)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.674056 108.737979) (xy 131.678435 108.743578) (xy 131.922406 109.401558) (xy 131.922069 109.410507)
-				(xy 131.919709 109.413899) (xy 131.789221 109.544387) (xy 131.780948 109.547814) (xy 131.776293 109.546848)
-				(xy 131.381936 109.375787) (xy 131.044848 109.229569) (xy 131.038622 109.223133) (xy 131.038684 109.214383)
-				(xy 131.196879 108.830154) (xy 131.203197 108.82381) (xy 131.205517 108.823115) (xy 131.665292 108.73615)
-			)
-		)
-	)
-	(zone
-		(net 46)
-		(net_name "Net-(RN1A-R1.1)")
-		(layer "F.Cu")
-		(uuid "c6ec590a-4060-41ac-a092-47f8b24b48b7")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30115)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 129.757323 116.934099) (xy 129.934099 116.757323) (xy 129.967388 116.613268) (xy 129.774293 115.861793)
-				(xy 129.632012 116.664234)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 129.785981 115.91027) (xy 129.787723 115.91406) (xy 129.966677 116.610502) (xy 129.966745 116.616048)
-				(xy 129.934853 116.754056) (xy 129.931726 116.759695) (xy 129.769158 116.922263) (xy 129.760885 116.92569)
-				(xy 129.752612 116.922263) (xy 129.750275 116.918921) (xy 129.633562 116.667573) (xy 129.632655 116.660606)
-				(xy 129.764871 115.914928) (xy 129.769689 115.907382) (xy 129.778434 115.905452)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "c7ed6267-0f2f-4e21-95ec-466d6d409d8d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30091)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 108.9 93.6875) (xy 108.9 94.1875) (xy 109.2 94.2375) (xy 109.501 93.9375) (xy 109.2 93.6375)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 109.202796 93.640507) (xy 109.204255 93.641741) (xy 109.492685 93.929213) (xy 109.496126 93.937481)
-				(xy 109.492713 93.945759) (xy 109.492685 93.945787) (xy 109.204255 94.233258) (xy 109.195977 94.236671)
-				(xy 109.194073 94.236512) (xy 108.909777 94.189129) (xy 108.902179 94.184388) (xy 108.9 94.177588)
-				(xy 108.9 93.697411) (xy 108.903427 93.689138) (xy 108.909775 93.68587) (xy 109.194075 93.638487)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "c8895a2c-d055-4b3f-ba7f-2be59710a195")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30080)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 134.394236 93.25) (xy 134.394236 92.75) (xy 133.858527 92.705764) (xy 133.799 93) (xy 133.858527 93.294236)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 134.394236 92.75) (xy 134.394236 93.25) (xy 133.858527 93.294236) (xy 133.799 93) (xy 133.858527 92.705764)
-			)
-		)
-	)
-	(zone
-		(net 14)
-		(net_name "Relay-")
-		(layer "F.Cu")
-		(uuid "cba2e214-a905-4a0d-8345-a77dbff1e361")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30111)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 111.05 92.1875) (xy 111.05 91.9375) (xy 110.75 91.7625) (xy 110.449 92.0625) (xy 110.75 92.3625)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 110.757775 91.767035) (xy 111.044196 91.934114) (xy 111.049615 91.941241) (xy 111.05 91.944219)
-				(xy 111.05 92.18078) (xy 111.046573 92.189053) (xy 111.044195 92.190886) (xy 110.757777 92.357963)
-				(xy 110.748904 92.359172) (xy 110.743623 92.356144) (xy 110.575975 92.189053) (xy 110.457313 92.070785)
-				(xy 110.453873 92.062519) (xy 110.457285 92.054241) (xy 110.743624 91.768854) (xy 110.751901 91.765442)
-			)
-		)
-	)
-	(zone
-		(net 8)
-		(net_name "Net-(U1A-+)")
-		(layer "F.Cu")
-		(uuid "cdaab6eb-457f-40c8-99ad-8cc99397bc7e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30054)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 140.696967 115.498743) (xy 140.873743 115.321967) (xy 141.159099 114.909099) (xy 140.749293 114.524293)
-				(xy 140.312874 114.867154)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 140.756621 114.531174) (xy 141.1076 114.860742) (xy 141.151756 114.902204) (xy 141.155441 114.910365)
-				(xy 141.153372 114.917385) (xy 140.874344 115.321096) (xy 140.872992 115.322717) (xy 140.707498 115.488211)
-				(xy 140.699225 115.491638) (xy 140.690952 115.488211) (xy 140.689228 115.486017) (xy 140.318266 114.876021)
-				(xy 140.316896 114.867172) (xy 140.321034 114.860743) (xy 140.741387 114.530503) (xy 140.750009 114.528087)
-			)
-		)
-	)
-	(zone
-		(net 35)
-		(net_name "+5V")
-		(layer "F.Cu")
-		(uuid "d0059cdd-6869-4c64-882a-54d68d31ed53")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30043)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 138.501257 91.921967) (xy 138.678033 92.098743) (xy 139.163896 92.407873) (xy 139.500707 91.974293)
-				(xy 139.163896 91.542127)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 139.170136 91.550134) (xy 139.49511 91.967112) (xy 139.497493 91.975744) (xy 139.495122 91.981482)
-				(xy 139.170429 92.399461) (xy 139.162647 92.403892) (xy 139.154908 92.402154) (xy 138.679116 92.099432)
-				(xy 138.677124 92.097834) (xy 138.512073 91.932783) (xy 138.508646 91.92451) (xy 138.512073 91.916237)
-				(xy 138.51452 91.914364) (xy 139.155089 91.547174) (xy 139.163971 91.546034)
-			)
-		)
-	)
-	(zone
-		(net 5)
-		(net_name "Net-(D1-K)")
-		(layer "F.Cu")
-		(uuid "d6bde172-d389-4304-9dfa-dc59d950e473")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30012)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 96.6 101.125) (xy 96.6 100.875) (xy 95.726777 100.273223) (xy 94.999 101) (xy 95.726777 101.726777)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 95.734793 100.278747) (xy 96.594939 100.871512) (xy 96.599807 100.879028) (xy 96.6 100.881146)
-				(xy 96.6 101.118853) (xy 96.596573 101.127126) (xy 96.594939 101.128487) (xy 95.734793 101.721252)
-				(xy 95.726036 101.723125) (xy 95.719888 101.719897) (xy 95.007289 101.008278) (xy 95.003857 101.000008)
-				(xy 95.007278 100.991733) (xy 95.00729 100.991721) (xy 95.719889 100.2801) (xy 95.728162 100.276681)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "d8eddcd0-6846-492e-9122-1036e164fecd")
+		(uuid "98b63010-063a-4b41-9c00-507006c62952")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30034)
@@ -27061,206 +25678,7 @@
 		(net 44)
 		(net_name "Net-(RN1A-R1.2)")
 		(layer "F.Cu")
-		(uuid "de30638f-7930-4740-bba5-be407c3fe466")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30068)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 130.251257 108.771967) (xy 130.428033 108.948743) (xy 130.848463 109.209776) (xy 131.200707 108.824293)
-				(xy 130.848463 108.440224)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 130.8547 108.447025) (xy 131.193467 108.816399) (xy 131.196533 108.824812) (xy 131.193481 108.832199)
-				(xy 130.855017 109.202603) (xy 130.846907 109.206399) (xy 130.840209 109.204651) (xy 130.42918 108.949455)
-				(xy 130.427078 108.947788) (xy 130.262225 108.782935) (xy 130.258798 108.774662) (xy 130.262225 108.766389)
-				(xy 130.26481 108.764438) (xy 130.840396 108.444704) (xy 130.849292 108.443683)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "F.Cu")
-		(uuid "de6bb054-2076-4a3c-8da8-175dcc17b485")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30022)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 130.775 91.55) (xy 130.775 92.05) (xy 131.429329 92.28097) (xy 132.001 91.8) (xy 131.429329 91.31903)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.431963 91.321734) (xy 131.434447 91.323336) (xy 131.990358 91.791047) (xy 131.994483 91.798996)
-				(xy 131.991779 91.807532) (xy 131.990358 91.808953) (xy 131.434447 92.276663) (xy 131.425911 92.279367)
-				(xy 131.423021 92.278743) (xy 130.782806 92.052755) (xy 130.776145 92.04677) (xy 130.775 92.041722)
-				(xy 130.775 91.558277) (xy 130.778427 91.550004) (xy 130.782803 91.547245) (xy 131.423022 91.321256)
-			)
-		)
-	)
-	(zone
-		(net 11)
-		(net_name "Net-(D2-A)")
-		(layer "F.Cu")
-		(uuid "e3a1a59d-a539-48fb-b490-cc033989425a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30003)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 92.85 105.149215) (xy 92.35 105.149215) (xy 91.619215 106.93491) (xy 92.6 107.131) (xy 93.580785 106.93491)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 92.85042 105.152642) (xy 92.852975 105.156484) (xy 93.575414 106.921786) (xy 93.575376 106.93074)
-				(xy 93.569017 106.937045) (xy 93.56688 106.93769) (xy 92.602294 107.130541) (xy 92.597706 107.130541)
-				(xy 91.91842 106.99473) (xy 91.633118 106.937689) (xy 91.625678 106.932708) (xy 91.62394 106.923923)
-				(xy 91.624582 106.921794) (xy 92.347025 105.156483) (xy 92.35333 105.150125) (xy 92.357853 105.149215)
-				(xy 92.842147 105.149215)
-			)
-		)
-	)
-	(zone
-		(net 36)
-		(net_name "-5V")
-		(layer "F.Cu")
-		(uuid "e6606cb6-b278-48c3-8c8c-ec5bf7a6124b")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30051)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 140.42929 108.506066) (xy 140.606066 108.32929) (xy 140.909099 107.909099) (xy 140.499293 107.524293)
-				(xy 140.056042 107.85693)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 140.50646 107.531023) (xy 140.901605 107.902062) (xy 140.90529 107.910223) (xy 140.903086 107.917435)
-				(xy 140.606614 108.328529) (xy 140.605397 108.329958) (xy 140.440091 108.495264) (xy 140.431818 108.498691)
-				(xy 140.423545 108.495264) (xy 140.421675 108.492823) (xy 140.327645 108.32929) (xy 140.061201 107.865903)
-				(xy 140.060049 107.857025) (xy 140.06432 107.850717) (xy 140.49143 107.530193) (xy 140.500102 107.527969)
-			)
-		)
-	)
-	(zone
-		(net 21)
-		(net_name "Net-(J2-DDCIO)")
-		(layer "F.Cu")
-		(uuid "e69d67fd-317e-4f0e-bda3-4886bf70189e")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30020)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 121.608882 98.434696) (xy 121.750304 98.576118) (xy 122.716809 98.23251) (xy 122.590707 97.594293)
-				(xy 121.95249 97.468191)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 122.583016 97.592773) (xy 122.590468 97.597738) (xy 122.592226 97.601983) (xy 122.714851 98.222601)
-				(xy 122.713093 98.231382) (xy 122.707292 98.235893) (xy 121.757268 98.573641) (xy 121.748325 98.573183)
-				(xy 121.745076 98.57089) (xy 121.614109 98.439923) (xy 121.610682 98.43165) (xy 121.611358 98.427731)
-				(xy 121.949107 97.477705) (xy 121.955106 97.47106) (xy 121.962395 97.470148)
-			)
-		)
-	)
-	(zone
-		(net 44)
-		(net_name "Net-(RN1A-R1.2)")
-		(layer "F.Cu")
-		(uuid "e73a033f-c094-45d0-a0de-e16cbb42acb7")
+		(uuid "9a782298-77b6-4ad7-896d-51d17b669b5f")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30098)
@@ -27296,366 +25714,10 @@
 		)
 	)
 	(zone
-		(net 36)
-		(net_name "-5V")
-		(layer "F.Cu")
-		(uuid "e76cfff6-f222-4f98-abb6-5f602ae14c00")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30030)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 144.376777 108.723224) (xy 144.023224 109.076777) (xy 143.823223 109.348223) (xy 144.250707 110.000707)
-				(xy 144.724467 109.419596)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 144.381837 108.734709) (xy 144.384032 108.737756) (xy 144.721091 109.412834) (xy 144.72172 109.421766)
-				(xy 144.719691 109.425453) (xy 144.260804 109.988321) (xy 144.252921 109.992568) (xy 144.244343 109.989996)
-				(xy 144.241949 109.98734) (xy 143.82768 109.355026) (xy 143.826013 109.346228) (xy 143.828048 109.341674)
-				(xy 144.022706 109.077479) (xy 144.023839 109.076161) (xy 144.365292 108.734708) (xy 144.373564 108.731282)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "e96f3054-839c-4270-9e6b-233fa2991871")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30095)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 133.991424 112.731799) (xy 134.168201 112.908576) (xy 134.666671 112.649441) (xy 134.500707 112.399293)
-				(xy 134.250559 112.233329)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 134.260333 112.239892) (xy 134.2614 112.240521) (xy 134.487419 112.390477) (xy 134.498734 112.397984)
-				(xy 134.502015 112.401265) (xy 134.659475 112.638595) (xy 134.661194 112.647383) (xy 134.656194 112.654812)
-				(xy 134.655123 112.655444) (xy 134.175808 112.904621) (xy 134.166887 112.905397) (xy 134.162138 112.902513)
-				(xy 133.997486 112.737861) (xy 133.994059 112.729588) (xy 133.995377 112.724194) (xy 134.244557 112.244874)
-				(xy 134.251412 112.239116)
-			)
-		)
-	)
-	(zone
-		(net 3)
-		(net_name "Net-(J2-DDCCL)")
-		(layer "F.Cu")
-		(uuid "e984d78b-a894-418e-ba5d-094b0136c65d")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30055)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 122.049112 95.625888) (xy 122.225888 95.449112) (xy 121.619003 95.064109) (xy 121.274293 95.499293)
-				(xy 121.659099 95.909099)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 121.627899 95.069753) (xy 121.934304 95.264133) (xy 122.213554 95.441287) (xy 122.218704 95.448613)
-				(xy 122.217166 95.457435) (xy 122.215559 95.45944) (xy 122.049765 95.625234) (xy 122.048367 95.626428)
-				(xy 121.667443 95.903039) (xy 121.658735 95.905127) (xy 121.65204 95.901581) (xy 121.281202 95.506651)
-				(xy 121.278038 95.498275) (xy 121.280559 95.491381) (xy 121.612461 95.072366) (xy 121.620283 95.068011)
-			)
-		)
-	)
-	(zone
-		(net 44)
-		(net_name "Net-(RN1A-R1.2)")
-		(layer "F.Cu")
-		(uuid "ea388604-4721-4d4b-ad33-374e77e0d63a")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30103)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 131.2 114.85) (xy 130.95 114.85) (xy 130.882612 115.111732) (xy 131.075 115.8635) (xy 131.267388 115.111732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.199204 114.853427) (xy 131.202261 114.858783) (xy 131.266638 115.108822) (xy 131.266643 115.11464)
-				(xy 131.086335 115.819207) (xy 131.080964 115.826372) (xy 131.072099 115.827641) (xy 131.064934 115.82227)
-				(xy 131.063665 115.819207) (xy 130.883356 115.11464) (xy 130.883361 115.108822) (xy 130.947739 114.858783)
-				(xy 130.95312 114.851625) (xy 130.959069 114.85) (xy 131.190931 114.85)
-			)
-		)
-	)
-	(zone
-		(net 42)
-		(net_name "Net-(J5-Pin_1)")
-		(layer "F.Cu")
-		(uuid "ea7d1538-b426-41ab-8710-1e153b5b6ad7")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30006)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 151.75 97.494695) (xy 151.25 97.494695) (xy 150.647744 98.930541) (xy 151.5 99.501) (xy 152.352256 98.930541)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 151.750493 97.498122) (xy 151.753009 97.501869) (xy 152.348527 98.921652) (xy 152.348567 98.930607)
-				(xy 152.344246 98.935901) (xy 151.506508 99.496643) (xy 151.497727 99.498397) (xy 151.493492 99.496643)
-				(xy 150.655753 98.935901) (xy 150.650784 98.928451) (xy 150.651472 98.921652) (xy 151.246991 97.501869)
-				(xy 151.253351 97.495566) (xy 151.25778 97.494695) (xy 151.74222 97.494695)
-			)
-		)
-	)
-	(zone
-		(net 6)
-		(net_name "GND")
-		(layer "F.Cu")
-		(uuid "ee77ed25-e3e1-4d50-82da-5f41a321347c")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30113)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 119.85 95.861094) (xy 119.6 95.861094) (xy 119.805764 96.358527) (xy 120.1 96.301) (xy 120.266671 96.050559)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 119.852306 95.862142) (xy 119.885565 95.877266) (xy 120.254158 96.044869) (xy 120.260271 96.051413)
-				(xy 120.259966 96.060363) (xy 120.259055 96.062002) (xy 120.102704 96.296935) (xy 120.095268 96.301924)
-				(xy 120.095209 96.301936) (xy 119.81516 96.356689) (xy 119.806383 96.354913) (xy 119.802104 96.349679)
-				(xy 119.60669 95.877266) (xy 119.606695 95.868311) (xy 119.61303 95.861982) (xy 119.617502 95.861094)
-				(xy 119.847464 95.861094)
-			)
-		)
-	)
-	(zone
-		(net 39)
-		(net_name "-12V")
-		(layer "F.Cu")
-		(uuid "ef097268-dc17-4a9c-83df-7f573f1022f6")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30042)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 123.125 93.0875) (xy 122.875 93.0875) (xy 122.5625 93.628835) (xy 123 93.9635) (xy 123.4375 93.628835)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 123.126518 93.090927) (xy 123.128378 93.093351) (xy 123.432362 93.619935) (xy 123.43353 93.628813)
-				(xy 123.429338 93.635077) (xy 123.007109 93.958061) (xy 122.998455 93.960366) (xy 122.992891 93.958061)
-				(xy 122.570661 93.635077) (xy 122.566172 93.627329) (xy 122.567636 93.619937) (xy 122.871622 93.09335)
-				(xy 122.878726 93.087899) (xy 122.881755 93.0875) (xy 123.118245 93.0875)
-			)
-		)
-	)
-	(zone
-		(net 7)
-		(net_name "Net-(RN1B-R2.2)")
-		(layer "F.Cu")
-		(uuid "f5f6476f-6637-41ee-9a68-1071b3d47bed")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30107)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 136.675 110.625) (xy 136.475 110.625) (xy 136.382612 110.886732) (xy 136.575 111.6385) (xy 136.767388 110.886732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 136.674995 110.628427) (xy 136.677755 110.632806) (xy 136.766204 110.88338) (xy 136.766506 110.890175)
-				(xy 136.586335 111.594207) (xy 136.580964 111.601372) (xy 136.572099 111.602641) (xy 136.564934 111.59727)
-				(xy 136.563665 111.594207) (xy 136.383493 110.890175) (xy 136.383795 110.88338) (xy 136.472245 110.632806)
-				(xy 136.47823 110.626145) (xy 136.483278 110.625) (xy 136.666722 110.625)
-			)
-		)
-	)
-	(zone
-		(net 7)
-		(net_name "Net-(RN1B-R2.2)")
-		(layer "F.Cu")
-		(uuid "f8daf837-5cdb-479e-acfa-5485ebe89114")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30096)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 131.85 114.85) (xy 131.6 114.85) (xy 131.532612 115.111732) (xy 131.725 115.8635) (xy 131.917388 115.111732)
-			)
-		)
-		(filled_polygon
-			(layer "F.Cu")
-			(pts
-				(xy 131.849204 114.853427) (xy 131.852261 114.858783) (xy 131.916638 115.108822) (xy 131.916643 115.11464)
-				(xy 131.736335 115.819207) (xy 131.730964 115.826372) (xy 131.722099 115.827641) (xy 131.714934 115.82227)
-				(xy 131.713665 115.819207) (xy 131.533356 115.11464) (xy 131.533361 115.108822) (xy 131.597739 114.858783)
-				(xy 131.60312 114.851625) (xy 131.609069 114.85) (xy 131.840931 114.85)
-			)
-		)
-	)
-	(zone
 		(net 12)
 		(net_name "Net-(D4-A)")
 		(layer "F.Cu")
-		(uuid "f96c26b6-1cc1-48fc-9fd2-0b7d5eb9cc8e")
+		(uuid "9d5b3e04-d590-48de-b441-6e596fa42df0")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30011)
@@ -27695,7 +25757,7 @@
 		(net 6)
 		(net_name "GND")
 		(layer "F.Cu")
-		(uuid "f9e430dd-fecd-42b6-9f84-36f5b933164d")
+		(uuid "9f1d3d4d-f103-4a1e-91a8-28ef97738a73")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30094)
@@ -27731,10 +25793,1390 @@
 		)
 	)
 	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "9f363278-b7a5-4199-bfb2-bb1aa65e1f93")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30047)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 140.484099 91.992677) (xy 140.307323 91.815901) (xy 139.836104 91.542127) (xy 139.499293 91.975707)
+				(xy 139.848972 92.399274)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 139.844947 91.547265) (xy 139.850006 91.550204) (xy 140.306009 91.815137) (xy 140.308402 91.81698)
+				(xy 140.473814 91.982392) (xy 140.477241 91.990665) (xy 140.473814 91.998938) (xy 140.471849 92.000519)
+				(xy 139.857703 92.393684) (xy 139.848888 92.395258) (xy 139.842372 92.391279) (xy 139.70408 92.223766)
+				(xy 139.505257 91.982932) (xy 139.502634 91.974371) (xy 139.505039 91.968309) (xy 139.82983 91.550203)
+				(xy 139.837611 91.545773)
+			)
+		)
+	)
+	(zone
+		(net 4)
+		(net_name "LD_short-")
+		(layer "F.Cu")
+		(uuid "a0517e01-e53f-492a-b6da-23a352f365c1")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30024)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 116.68 114.75) (xy 116.68 115.25) (xy 117.301804 115.525) (xy 117.731 115) (xy 117.301804 114.475)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 117.307444 114.481899) (xy 117.724946 114.992595) (xy 117.727529 115.001169) (xy 117.724946 115.007405)
+				(xy 117.307444 115.5181) (xy 117.299555 115.522336) (xy 117.293654 115.521395) (xy 116.686968 115.253081)
+				(xy 116.680788 115.246601) (xy 116.68 115.242381) (xy 116.68 114.757618) (xy 116.683427 114.749345)
+				(xy 116.686966 114.746918) (xy 117.293655 114.478603) (xy 117.302606 114.478392)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "Net-(J2-DDCCL)")
+		(layer "F.Cu")
+		(uuid "a516f653-e9d6-4f41-ae31-575f53b705a2")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30055)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 122.049112 95.625888) (xy 122.225888 95.449112) (xy 121.619003 95.064109) (xy 121.274293 95.499293)
+				(xy 121.659099 95.909099)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 121.627899 95.069753) (xy 121.934304 95.264133) (xy 122.213554 95.441287) (xy 122.218704 95.448613)
+				(xy 122.217166 95.457435) (xy 122.215559 95.45944) (xy 122.049765 95.625234) (xy 122.048367 95.626428)
+				(xy 121.667443 95.903039) (xy 121.658735 95.905127) (xy 121.65204 95.901581) (xy 121.281202 95.506651)
+				(xy 121.278038 95.498275) (xy 121.280559 95.491381) (xy 121.612461 95.072366) (xy 121.620283 95.068011)
+			)
+		)
+	)
+	(zone
+		(net 41)
+		(net_name "Curr_Mod")
+		(layer "F.Cu")
+		(uuid "a8023183-2bba-41e4-b59b-e317e10bafc3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30058)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 115.7 105.375) (xy 115.95 105.375) (xy 116.209776 104.851537) (xy 115.825 104.499) (xy 115.440224 104.851537)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 115.832902 104.50624) (xy 116.095197 104.746558) (xy 116.203287 104.845592) (xy 116.207072 104.853708)
+				(xy 116.205863 104.85942) (xy 115.953225 105.368501) (xy 115.946478 105.374388) (xy 115.942745 105.375)
+				(xy 115.707255 105.375) (xy 115.698982 105.371573) (xy 115.696775 105.368501) (xy 115.444136 104.85942)
+				(xy 115.443528 104.850486) (xy 115.446711 104.845593) (xy 115.817097 104.50624) (xy 115.825511 104.503179)
+			)
+		)
+	)
+	(zone
+		(net 7)
+		(net_name "Net-(RN1B-R2.2)")
+		(layer "F.Cu")
+		(uuid "a90b46e1-6933-4174-b393-c80f00f414e3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30123)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 132.125 115.9875) (xy 132.125 115.7375) (xy 131.925 115.6625) (xy 131.724 115.8625) (xy 131.925 116.0625)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.93203 115.665136) (xy 132.117408 115.734653) (xy 132.123951 115.740767) (xy 132.125 115.745608)
+				(xy 132.125 115.979392) (xy 132.121573 115.987665) (xy 132.117408 115.990347) (xy 131.932034 116.059862)
+				(xy 131.923084 116.059558) (xy 131.919675 116.057202) (xy 131.732334 115.870793) (xy 131.728887 115.862529)
+				(xy 131.732293 115.854248) (xy 131.919677 115.667796) (xy 131.927955 115.664392)
+			)
+		)
+	)
+	(zone
+		(net 7)
+		(net_name "Net-(RN1B-R2.2)")
+		(layer "F.Cu")
+		(uuid "aae6774c-ce99-4b70-89b5-63622cc41081")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30074)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 132.850889 115.774113) (xy 132.674113 115.950889) (xy 133.080609 116.393696) (xy 133.500707 116.025707)
+				(xy 133.163896 115.592127)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 133.170172 115.600206) (xy 133.49394 116.016996) (xy 133.496309 116.025632) (xy 133.492409 116.032975)
+				(xy 133.089206 116.386164) (xy 133.080725 116.389038) (xy 133.072878 116.385275) (xy 132.681692 115.959145)
+				(xy 132.678623 115.950735) (xy 132.682038 115.942963) (xy 132.849814 115.775187) (xy 132.852198 115.773351)
+				(xy 133.155052 115.597268) (xy 133.163926 115.596074)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "aec6190a-8edd-429e-9bcd-f2b839003507")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30113)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 119.85 95.861094) (xy 119.6 95.861094) (xy 119.805764 96.358527) (xy 120.1 96.301) (xy 120.266671 96.050559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 119.852306 95.862142) (xy 119.885565 95.877266) (xy 120.254158 96.044869) (xy 120.260271 96.051413)
+				(xy 120.259966 96.060363) (xy 120.259055 96.062002) (xy 120.102704 96.296935) (xy 120.095268 96.301924)
+				(xy 120.095209 96.301936) (xy 119.81516 96.356689) (xy 119.806383 96.354913) (xy 119.802104 96.349679)
+				(xy 119.60669 95.877266) (xy 119.606695 95.868311) (xy 119.61303 95.861982) (xy 119.617502 95.861094)
+				(xy 119.847464 95.861094)
+			)
+		)
+	)
+	(zone
+		(net 11)
+		(net_name "Net-(D2-A)")
+		(layer "F.Cu")
+		(uuid "b171dae8-15ee-4b5b-9b7f-b9ee3960453a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30003)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 92.85 105.149215) (xy 92.35 105.149215) (xy 91.619215 106.93491) (xy 92.6 107.131) (xy 93.580785 106.93491)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 92.85042 105.152642) (xy 92.852975 105.156484) (xy 93.575414 106.921786) (xy 93.575376 106.93074)
+				(xy 93.569017 106.937045) (xy 93.56688 106.93769) (xy 92.602294 107.130541) (xy 92.597706 107.130541)
+				(xy 91.91842 106.99473) (xy 91.633118 106.937689) (xy 91.625678 106.932708) (xy 91.62394 106.923923)
+				(xy 91.624582 106.921794) (xy 92.347025 105.156483) (xy 92.35333 105.150125) (xy 92.357853 105.149215)
+				(xy 92.842147 105.149215)
+			)
+		)
+	)
+	(zone
+		(net 13)
+		(net_name "Net-(J1-In)")
+		(layer "F.Cu")
+		(uuid "b4836869-b9c6-4304-a75b-de4a960f2cff")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30013)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 145.95 114.25) (xy 145.95 113.75) (xy 145.295671 113.51903) (xy 143.749 114) (xy 145.295671 114.48097)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 145.299331 113.520322) (xy 145.942195 113.747244) (xy 145.948855 113.753229) (xy 145.95 113.758277)
+				(xy 145.95 114.241722) (xy 145.946573 114.249995) (xy 145.942194 114.252755) (xy 145.299331 114.479677)
+				(xy 145.291963 114.479816) (xy 143.784926 114.011172) (xy 143.778043 114.005443) (xy 143.777228 113.996526)
+				(xy 143.782957 113.989643) (xy 143.784926 113.988828) (xy 145.291963 113.520183)
+			)
+		)
+	)
+	(zone
+		(net 30)
+		(net_name "V_diode+")
+		(layer "F.Cu")
+		(uuid "b59d791a-aeb7-4ae4-8bdc-d14c3018b3c5")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30066)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 114.275 103.625) (xy 114.075 103.625) (xy 113.790224 104.148463) (xy 114.175 104.501) (xy 114.559776 104.148463)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 114.276318 103.628427) (xy 114.278323 103.631109) (xy 114.555403 104.140426) (xy 114.556346 104.149331)
+				(xy 114.553029 104.154644) (xy 114.182904 104.493758) (xy 114.174489 104.49682) (xy 114.167096 104.493758)
+				(xy 113.79697 104.154644) (xy 113.793185 104.146528) (xy 113.794596 104.140426) (xy 114.071677 103.631109)
+				(xy 114.078641 103.625479) (xy 114.081955 103.625) (xy 114.268045 103.625)
+			)
+		)
+	)
+	(zone
+		(net 13)
+		(net_name "Net-(J1-In)")
+		(layer "F.Cu")
+		(uuid "b8204130-ad81-4fca-8f4c-07b431ef0672")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30071)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 144.092677 114.815901) (xy 143.915901 114.992677) (xy 143.690224 115.398463) (xy 144.075707 115.750707)
+				(xy 144.445619 115.377277)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 144.098851 114.826272) (xy 144.100483 114.828318) (xy 144.440675 115.369414) (xy 144.442177 115.378241)
+				(xy 144.439082 115.383875) (xy 144.083615 115.742723) (xy 144.075358 115.746189) (xy 144.067411 115.743126)
+				(xy 143.953046 115.638623) (xy 143.697051 115.404701) (xy 143.693256 115.396593) (xy 143.694718 115.390381)
+				(xy 143.915109 114.9941) (xy 143.917054 114.991523) (xy 144.082306 114.826271) (xy 144.090578 114.822845)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "ba83f06d-c4e0-4629-a1d7-66b61085cea3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30091)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 108.9 93.6875) (xy 108.9 94.1875) (xy 109.2 94.2375) (xy 109.501 93.9375) (xy 109.2 93.6375)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 109.202796 93.640507) (xy 109.204255 93.641741) (xy 109.492685 93.929213) (xy 109.496126 93.937481)
+				(xy 109.492713 93.945759) (xy 109.492685 93.945787) (xy 109.204255 94.233258) (xy 109.195977 94.236671)
+				(xy 109.194073 94.236512) (xy 108.909777 94.189129) (xy 108.902179 94.184388) (xy 108.9 94.177588)
+				(xy 108.9 93.697411) (xy 108.903427 93.689138) (xy 108.909775 93.68587) (xy 109.194075 93.638487)
+			)
+		)
+	)
+	(zone
+		(net 46)
+		(net_name "Net-(RN1A-R1.1)")
+		(layer "F.Cu")
+		(uuid "ba8c4d41-d55e-4d4a-8139-c15fda7ac578")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30112)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 135.151257 116.771967) (xy 135.328033 116.948743) (xy 135.447631 116.642837) (xy 135.275707 115.861793)
+				(xy 135.082612 116.613268)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 135.2849 115.90627) (xy 135.286254 115.909709) (xy 135.446867 116.639368) (xy 135.446338 116.646143)
+				(xy 135.334549 116.932076) (xy 135.328345 116.938534) (xy 135.319392 116.938713) (xy 135.315379 116.936089)
+				(xy 135.152835 116.773545) (xy 135.15037 116.769917) (xy 135.095402 116.642837) (xy 135.084201 116.616943)
+				(xy 135.083608 116.60939) (xy 135.263497 115.90931) (xy 135.268874 115.902152) (xy 135.27774 115.900892)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "baa268a8-9d08-481c-8d73-4bc3989c6a0b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30125)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 134.875 111.5125) (xy 134.875 111.7625) (xy 135.075 111.8375) (xy 135.276 111.6375) (xy 135.075 111.4375)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 135.076914 111.440441) (xy 135.080321 111.442794) (xy 135.267665 111.629206) (xy 135.271112 111.637471)
+				(xy 135.267706 111.645753) (xy 135.267664 111.645794) (xy 135.080325 111.832201) (xy 135.072044 111.835607)
+				(xy 135.067965 111.834862) (xy 134.882592 111.765347) (xy 134.876049 111.759233) (xy 134.875 111.754392)
+				(xy 134.875 111.520608) (xy 134.878427 111.512335) (xy 134.882592 111.509653) (xy 135.067967 111.440137)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "bb017cee-849c-4564-b1e9-44a0139c810a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30077)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 144.705764 103.25) (xy 144.705764 103.75) (xy 145.241473 103.794236) (xy 145.301 103.5) (xy 145.241473 103.205764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 145.301 103.5) (xy 145.241473 103.794236) (xy 144.705764 103.75) (xy 144.705764 103.25) (xy 145.241473 103.205764)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "beafdc32-8e4d-4495-b236-b2805e87bdfa")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30082)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 135.971235 92.175511) (xy 136.148011 91.998735) (xy 135.698973 91.77249) (xy 135.111793 92.049293)
+				(xy 135.682403 92.338582)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 135.704065 91.775056) (xy 136.13356 91.991454) (xy 136.139407 91.998237) (xy 136.138745 92.007167)
+				(xy 136.136569 92.010176) (xy 135.972364 92.174381) (xy 135.969843 92.176296) (xy 135.687858 92.335502)
+				(xy 135.678969 92.336586) (xy 135.676815 92.335749) (xy 135.362301 92.176296) (xy 135.133128 92.060109)
+				(xy 135.1273 92.053313) (xy 135.127985 92.044384) (xy 135.133429 92.039093) (xy 135.693814 91.774921)
+				(xy 135.702757 91.774494)
+			)
+		)
+	)
+	(zone
+		(net 2)
+		(net_name "Net-(J2-+5V)")
+		(layer "F.Cu")
+		(uuid "bfa1f64f-e674-4842-9e39-02f06f66b44c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30019)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 125.476118 98.660304) (xy 125.334696 98.518882) (xy 124.368191 98.86249) (xy 124.494293 99.500707)
+				(xy 125.13251 99.626809)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 125.336674 98.521816) (xy 125.339923 98.524109) (xy 125.47089 98.655076) (xy 125.474317 98.663349)
+				(xy 125.473641 98.667268) (xy 125.135893 99.617292) (xy 125.129893 99.623939) (xy 125.122601 99.624851)
+				(xy 124.501983 99.502226) (xy 124.494531 99.497261) (xy 124.492773 99.493016) (xy 124.370148 98.872396)
+				(xy 124.371906 98.863617) (xy 124.377704 98.859107) (xy 125.327731 98.521358)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "bfdef683-7060-49fb-b54d-f58ff08be896")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30026)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 142.975 91.925) (xy 142.975 91.675) (xy 142.320671 91.31903) (xy 141.749 91.8) (xy 142.320671 92.28097)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 142.327683 91.322844) (xy 142.968891 91.671677) (xy 142.974521 91.67864) (xy 142.975 91.681954)
+				(xy 142.975 91.918045) (xy 142.971573 91.926318) (xy 142.968891 91.928323) (xy 142.327684 92.277154)
+				(xy 142.318779 92.278097) (xy 142.314561 92.275829) (xy 141.759641 91.808953) (xy 141.755516 91.801004)
+				(xy 141.75822 91.792468) (xy 141.759641 91.791047) (xy 141.901523 91.671676) (xy 142.314562 91.324169)
+				(xy 142.323097 91.321466)
+			)
+		)
+	)
+	(zone
 		(net 39)
 		(net_name "-12V")
 		(layer "F.Cu")
-		(uuid "fa5bb84e-6e58-4f30-8b9d-3ccf8937675d")
+		(uuid "c06cd969-3f8f-43c4-9bdd-782019d21e82")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30033)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 142.724264 102.502513) (xy 142.547487 102.325736) (xy 141.99741 102.78546) (xy 142.299293 103.500707)
+				(xy 142.8 103.025)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 142.555053 102.333302) (xy 142.721515 102.499764) (xy 142.724821 102.506359) (xy 142.799131 103.019009)
+				(xy 142.796926 103.027688) (xy 142.795611 103.029169) (xy 142.311554 103.489057) (xy 142.303196 103.492271)
+				(xy 142.295013 103.488634) (xy 142.292716 103.485125) (xy 142.000775 102.793434) (xy 142.000716 102.784481)
+				(xy 142.00405 102.77991) (xy 142.539277 102.332596) (xy 142.547823 102.329922)
+			)
+		)
+	)
+	(zone
+		(net 1)
+		(net_name "Net-(C3-Pad2)")
+		(layer "F.Cu")
+		(uuid "c214a93b-276e-4243-bd5e-a8df9679575a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30001)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 94.41066 113.292893) (xy 94.057107 112.93934) (xy 92.185786 113.75) (xy 92.599293 114.750707)
+				(xy 93.6 115.164214)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 94.062731 112.944964) (xy 94.405035 113.287268) (xy 94.408462 113.295541) (xy 94.407498 113.300192)
+				(xy 93.604572 115.153658) (xy 93.598139 115.159887) (xy 93.589368 115.15982) (xy 92.603782 114.752562)
+				(xy 92.597446 114.746238) (xy 92.190179 113.760631) (xy 92.190186 113.751676) (xy 92.19634 113.745427)
+				(xy 94.04981 112.9425) (xy 94.058761 112.942357)
+			)
+		)
+	)
+	(zone
+		(net 2)
+		(net_name "Net-(J2-+5V)")
+		(layer "F.Cu")
+		(uuid "c27a6f43-43e8-4613-90aa-4904741d2169")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30072)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 124.685615 96.377036) (xy 124.827036 96.235615) (xy 124.958349 95.839962) (xy 124.499293 95.536793)
+				(xy 124.180176 95.962354)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 124.508489 95.542866) (xy 124.950869 95.835022) (xy 124.955884 95.842441) (xy 124.955525 95.84847)
+				(xy 124.827908 96.232985) (xy 124.825077 96.237573) (xy 124.693112 96.369538) (xy 124.684839 96.372965)
+				(xy 124.677418 96.37031) (xy 124.396798 96.140079) (xy 124.188833 95.969456) (xy 124.184612 95.961561)
+				(xy 124.186893 95.953395) (xy 124.492682 95.545608) (xy 124.500385 95.541047)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "c4933ee2-2c6b-41b2-ba46-916dfddabe84")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30040)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 120.004809 96.381586) (xy 120.181586 96.204809) (xy 120.175 95.401368) (xy 119.724293 95.499293)
+				(xy 119.44395 95.963851)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 120.169745 95.406016) (xy 120.17485 95.413373) (xy 120.175117 95.415761) (xy 120.181545 96.199907)
+				(xy 120.178186 96.208208) (xy 120.01196 96.374434) (xy 120.003687 96.377861) (xy 119.996698 96.375544)
+				(xy 119.452462 95.970191) (xy 119.447874 95.962501) (xy 119.449434 95.954763) (xy 119.721688 95.503608)
+				(xy 119.728895 95.498297) (xy 119.729182 95.49823) (xy 120.160933 95.404424)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "c6807e6e-bbc1-4fe9-81d7-5cd67bde55fc")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30093)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 130.3 115.219236) (xy 130.55 115.219236) (xy 130.719236 114.683527) (xy 130.425 114.624) (xy 130.130764 114.683527)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 130.706479 114.680946) (xy 130.713907 114.685945) (xy 130.715626 114.694733) (xy 130.715315 114.695937)
+				(xy 130.552583 115.21106) (xy 130.546823 115.217917) (xy 130.541426 115.219236) (xy 130.308574 115.219236)
+				(xy 130.300301 115.215809) (xy 130.297417 115.21106) (xy 130.134684 114.695937) (xy 130.13546 114.687016)
+				(xy 130.142317 114.681256) (xy 130.1435 114.68095) (xy 130.422682 114.624469) (xy 130.427318 114.624469)
+			)
+		)
+	)
+	(zone
+		(net 3)
+		(net_name "Net-(J2-DDCCL)")
+		(layer "F.Cu")
+		(uuid "c74cca86-5341-43a8-9cdb-b7293aa40826")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30070)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 123.132582 96.409359) (xy 123.309359 96.232582) (xy 123.458349 95.839962) (xy 122.999293 95.536793)
+				(xy 122.664041 95.959145)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 123.008239 95.542701) (xy 123.450536 95.834802) (xy 123.455551 95.842221) (xy 123.455027 95.848716)
+				(xy 123.310249 96.230235) (xy 123.307583 96.234357) (xy 123.140692 96.401248) (xy 123.132419 96.404675)
+				(xy 123.124312 96.401412) (xy 122.671715 95.966519) (xy 122.668124 95.958315) (xy 122.670657 95.950809)
+				(xy 122.992628 95.545189) (xy 123.000455 95.540841)
+			)
+		)
+	)
+	(zone
+		(net 11)
+		(net_name "Net-(D2-A)")
+		(layer "F.Cu")
+		(uuid "c8bc5536-3f3e-49b1-9c36-51ec4a07203f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30109)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 109.15 92.1875) (xy 109.15 91.9375) (xy 108.85 91.7625) (xy 108.549 92.0625) (xy 108.85 92.3625)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 108.857775 91.767035) (xy 109.144196 91.934114) (xy 109.149615 91.941241) (xy 109.15 91.944219)
+				(xy 109.15 92.18078) (xy 109.146573 92.189053) (xy 109.144195 92.190886) (xy 108.857777 92.357963)
+				(xy 108.848904 92.359172) (xy 108.843623 92.356144) (xy 108.675975 92.189053) (xy 108.557313 92.070785)
+				(xy 108.553873 92.062519) (xy 108.557285 92.054241) (xy 108.843624 91.768854) (xy 108.851901 91.765442)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "ca175660-fc30-4445-96cb-0d7f43ffe3de")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30012)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 96.6 101.125) (xy 96.6 100.875) (xy 95.726777 100.273223) (xy 94.999 101) (xy 95.726777 101.726777)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 95.734793 100.278747) (xy 96.594939 100.871512) (xy 96.599807 100.879028) (xy 96.6 100.881146)
+				(xy 96.6 101.118853) (xy 96.596573 101.127126) (xy 96.594939 101.128487) (xy 95.734793 101.721252)
+				(xy 95.726036 101.723125) (xy 95.719888 101.719897) (xy 95.007289 101.008278) (xy 95.003857 101.000008)
+				(xy 95.007278 100.991733) (xy 95.00729 100.991721) (xy 95.719889 100.2801) (xy 95.728162 100.276681)
+			)
+		)
+	)
+	(zone
+		(net 6)
+		(net_name "GND")
+		(layer "F.Cu")
+		(uuid "d33ba2a7-4989-4a8f-be71-05c073035240")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30089)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 120.875 105.561094) (xy 120.375 105.561094) (xy 120.750559 106.166671) (xy 121 106.001) (xy 121.166671 105.750559)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 121.166671 105.750559) (xy 121 106.001) (xy 120.750559 106.166671) (xy 120.375 105.561094) (xy 120.875 105.561094)
+			)
+		)
+	)
+	(zone
+		(net 14)
+		(net_name "Relay-")
+		(layer "F.Cu")
+		(uuid "d344a730-fd80-4f01-a34d-b6558833f28b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30015)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 119.574482 99.197705) (xy 119.397705 99.374482) (xy 120.323879 100.040455) (xy 120.685707 99.500707)
+				(xy 120.558191 98.86249)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 120.554494 98.86737) (xy 120.560407 98.874095) (xy 120.560805 98.875577) (xy 120.684754 99.495939)
+				(xy 120.683015 99.504723) (xy 120.682999 99.504746) (xy 120.33061 100.030412) (xy 120.323157 100.035376)
+				(xy 120.314377 100.033615) (xy 120.314062 100.033396) (xy 119.408882 99.382519) (xy 119.404165 99.374907)
+				(xy 119.406213 99.36619) (xy 119.407433 99.364753) (xy 119.572559 99.199627) (xy 119.577052 99.196828)
+				(xy 120.54556 98.866794)
+			)
+		)
+	)
+	(zone
+		(net 14)
+		(net_name "Relay-")
+		(layer "F.Cu")
+		(uuid "d4dffd86-85b7-4185-bedc-aab7c0101f3f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30059)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 113.875 92.55) (xy 113.875 92.3) (xy 113.351537 92.040224) (xy 112.999 92.425) (xy 113.351537 92.809776)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 113.359419 92.044135) (xy 113.868502 92.296775) (xy 113.874388 92.303521) (xy 113.875 92.307254)
+				(xy 113.875 92.542745) (xy 113.871573 92.551018) (xy 113.868501 92.553225) (xy 113.35942 92.805863)
+				(xy 113.350486 92.806471) (xy 113.345592 92.803287) (xy 113.114459 92.551018) (xy 113.00624 92.432902)
+				(xy 113.003179 92.424489) (xy 113.00624 92.417097) (xy 113.345593 92.046711) (xy 113.353708 92.042927)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "d618c2eb-550c-4fac-a331-01c5ae83e58e")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30092)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 116.805764 95.175) (xy 116.805764 95.425) (xy 117.341473 95.594236) (xy 117.401 95.3) (xy 117.341473 95.005764)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 117.337983 95.01046) (xy 117.343743 95.017317) (xy 117.344054 95.018521) (xy 117.40053 95.29768)
+				(xy 117.40053 95.30232) (xy 117.344054 95.581478) (xy 117.339054 95.588907) (xy 117.330266 95.590626)
+				(xy 117.329062 95.590315) (xy 116.81394 95.427582) (xy 116.807083 95.421822) (xy 116.805764 95.416425)
+				(xy 116.805764 95.183574) (xy 116.809191 95.175301) (xy 116.81394 95.172417) (xy 117.329063 95.009684)
+			)
+		)
+	)
+	(zone
+		(net 7)
+		(net_name "Net-(RN1B-R2.2)")
+		(layer "F.Cu")
+		(uuid "d65d867c-e179-42c1-a7d6-c9fe82a507d3")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30096)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 131.85 114.85) (xy 131.6 114.85) (xy 131.532612 115.111732) (xy 131.725 115.8635) (xy 131.917388 115.111732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.849204 114.853427) (xy 131.852261 114.858783) (xy 131.916638 115.108822) (xy 131.916643 115.11464)
+				(xy 131.736335 115.819207) (xy 131.730964 115.826372) (xy 131.722099 115.827641) (xy 131.714934 115.82227)
+				(xy 131.713665 115.819207) (xy 131.533356 115.11464) (xy 131.533361 115.108822) (xy 131.597739 114.858783)
+				(xy 131.60312 114.851625) (xy 131.609069 114.85) (xy 131.840931 114.85)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "de0ec601-67b3-4132-8658-9c17c84ee01f")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30083)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 136.148011 94.001265) (xy 135.971235 93.824489) (xy 135.682403 93.661418) (xy 135.111793 93.950707)
+				(xy 135.698973 94.227509)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 135.687851 93.664494) (xy 135.969843 93.823703) (xy 135.972364 93.825618) (xy 136.136569 93.989823)
+				(xy 136.139996 93.998096) (xy 136.136569 94.006369) (xy 136.13356 94.008545) (xy 135.704066 94.224942)
+				(xy 135.695136 94.225604) (xy 135.693813 94.225076) (xy 135.133431 93.960907) (xy 135.127409 93.95428)
+				(xy 135.127837 93.945335) (xy 135.133127 93.939891) (xy 135.676817 93.664249) (xy 135.685744 93.663565)
+			)
+		)
+	)
+	(zone
+		(net 54)
+		(net_name "Net-(RN1C-R3.2)")
+		(layer "F.Cu")
+		(uuid "e1087c80-8682-4c7e-981f-b13eb8485653")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30100)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 131.6 112.65) (xy 131.85 112.65) (xy 131.917388 112.388268) (xy 131.725 111.6365) (xy 131.532612 112.388268)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 131.735066 111.677729) (xy 131.736335 111.680792) (xy 131.916643 112.385359) (xy 131.916638 112.391177)
+				(xy 131.852261 112.641217) (xy 131.84688 112.648375) (xy 131.840931 112.65) (xy 131.609069 112.65)
+				(xy 131.600796 112.646573) (xy 131.597739 112.641217) (xy 131.533361 112.391177) (xy 131.533356 112.385359)
+				(xy 131.713665 111.680792) (xy 131.719036 111.673627) (xy 131.727901 111.672358)
+			)
+		)
+	)
+	(zone
+		(net 41)
+		(net_name "Curr_Mod")
+		(layer "F.Cu")
+		(uuid "e15067ad-59c4-4230-a0e1-e5278ab4149b")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30014)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 120.073007 114.280546) (xy 119.719454 113.926993) (xy 119.007538 114.25) (xy 118.999293 115.000707)
+				(xy 119.525 115.217462)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 119.725183 113.932722) (xy 120.066621 114.27416) (xy 120.070048 114.282433) (xy 120.068447 114.28834)
+				(xy 119.530142 115.208669) (xy 119.523007 115.21408) (xy 119.515583 115.213579) (xy 119.006619 115.003727)
+				(xy 119.000277 114.997405) (xy 118.99938 114.992782) (xy 119.007182 114.282433) (xy 119.007456 114.257448)
+				(xy 119.010973 114.249213) (xy 119.014319 114.246923) (xy 119.712077 113.930339) (xy 119.721026 113.930043)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "e259365d-581c-4178-a44c-60e59dff5af6")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30060)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 112.125 93.95) (xy 112.125 94.2) (xy 112.648463 94.459776) (xy 113.001 94.075) (xy 112.648463 93.690224)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 112.654407 93.696712) (xy 112.993758 94.067096) (xy 112.99682 94.075511) (xy 112.993758 94.082904)
+				(xy 112.654407 94.453287) (xy 112.646291 94.457072) (xy 112.640579 94.455863) (xy 112.131499 94.203225)
+				(xy 112.125612 94.196478) (xy 112.125 94.192745) (xy 112.125 93.957254) (xy 112.128427 93.948981)
+				(xy 112.131495 93.946776) (xy 112.64058 93.694135) (xy 112.649513 93.693528)
+			)
+		)
+	)
+	(zone
+		(net 39)
+		(net_name "-12V")
+		(layer "F.Cu")
+		(uuid "e2a0b97e-1492-4471-9f14-541f423f3a28")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30084)
@@ -27767,6 +27209,564 @@
 				(xy 142.5858 107.312262) (xy 142.586587 107.321182) (xy 142.585861 107.322962) (xy 142.310464 107.866172)
 				(xy 142.303667 107.872001) (xy 142.294738 107.871316) (xy 142.289324 107.865602) (xy 142.035565 107.290179)
 				(xy 142.035362 107.281226) (xy 142.035982 107.279886) (xy 142.257171 106.872349) (xy 142.264127 106.866714)
+			)
+		)
+	)
+	(zone
+		(net 44)
+		(net_name "Net-(RN1A-R1.2)")
+		(layer "F.Cu")
+		(uuid "e513a95c-d0ca-4098-ab04-f6cd9147d440")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30106)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 137.325 110.625) (xy 137.125 110.625) (xy 137.032612 110.886732) (xy 137.225 111.6385) (xy 137.417388 110.886732)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 137.324995 110.628427) (xy 137.327755 110.632806) (xy 137.416204 110.88338) (xy 137.416506 110.890175)
+				(xy 137.236335 111.594207) (xy 137.230964 111.601372) (xy 137.222099 111.602641) (xy 137.214934 111.59727)
+				(xy 137.213665 111.594207) (xy 137.033493 110.890175) (xy 137.033795 110.88338) (xy 137.122245 110.632806)
+				(xy 137.12823 110.626145) (xy 137.133278 110.625) (xy 137.316722 110.625)
+			)
+		)
+	)
+	(zone
+		(net 5)
+		(net_name "Net-(D1-K)")
+		(layer "F.Cu")
+		(uuid "e5498434-8cf8-43e8-a70c-c1b0b6613739")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30008)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 109.067762 105.640985) (xy 108.890985 105.817762) (xy 109.399215 107.32509) (xy 110.380707 107.130707)
+				(xy 110.57509 106.149215)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 109.074639 105.643304) (xy 109.516842 105.792402) (xy 110.565356 106.145933) (xy 110.5721 106.151823)
+				(xy 110.573094 106.159292) (xy 110.382228 107.123024) (xy 110.377259 107.130474) (xy 110.373024 107.132228)
+				(xy 109.409292 107.323094) (xy 109.400511 107.32134) (xy 109.395933 107.315356) (xy 108.893304 105.824639)
+				(xy 108.893908 105.815705) (xy 108.896115 105.812631) (xy 109.062629 105.646117) (xy 109.070901 105.642691)
+			)
+		)
+	)
+	(zone
+		(net 39)
+		(net_name "-12V")
+		(layer "F.Cu")
+		(uuid "e5f3f77f-782a-41ea-912e-6b362f94235d")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30087)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 143.267677 104.590901) (xy 143.090901 104.767677) (xy 142.961418 105.042597) (xy 143.250707 105.613207)
+				(xy 143.504127 104.992638)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 143.273534 104.601589) (xy 143.275344 104.603927) (xy 143.501187 104.987643) (xy 143.50243 104.996511)
+				(xy 143.501936 104.998001) (xy 143.260391 105.589492) (xy 143.25409 105.595856) (xy 143.245136 105.595901)
+				(xy 143.239124 105.59036) (xy 143.231474 105.575272) (xy 142.964003 105.047697) (xy 142.963319 105.03877)
+				(xy 142.963849 105.037434) (xy 143.090033 104.769518) (xy 143.092341 104.766236) (xy 143.256989 104.601588)
+				(xy 143.265261 104.598162)
+			)
+		)
+	)
+	(zone
+		(net 14)
+		(net_name "Relay-")
+		(layer "F.Cu")
+		(uuid "ec6e2a58-467b-4b0a-a4f6-5609795ed678")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30122)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 116.05 93.925) (xy 116.05 94.175) (xy 116.28246 94.275) (xy 116.501 94.05) (xy 116.28246 93.825)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 116.288074 93.83078) (xy 116.493082 94.041848) (xy 116.496388 94.05017) (xy 116.493082 94.058152)
+				(xy 116.288074 94.269219) (xy 116.279851 94.272766) (xy 116.275058 94.271815) (xy 116.057077 94.178044)
+				(xy 116.050831 94.171627) (xy 116.05 94.167296) (xy 116.05 93.932703) (xy 116.053427 93.92443) (xy 116.057074 93.921956)
+				(xy 116.275058 93.828183) (xy 116.284012 93.828063)
+			)
+		)
+	)
+	(zone
+		(net 8)
+		(net_name "Net-(U1A-+)")
+		(layer "F.Cu")
+		(uuid "ec981995-59ec-4c42-a47f-2251ba0c4aab")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30101)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 136.45 116.875) (xy 136.7 116.875) (xy 136.767388 116.613268) (xy 136.575 115.8615) (xy 136.382612 116.613268)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 136.585066 115.902729) (xy 136.586335 115.905792) (xy 136.766643 116.610359) (xy 136.766638 116.616177)
+				(xy 136.702261 116.866217) (xy 136.69688 116.873375) (xy 136.690931 116.875) (xy 136.459069 116.875)
+				(xy 136.450796 116.871573) (xy 136.447739 116.866217) (xy 136.383361 116.616177) (xy 136.383356 116.610359)
+				(xy 136.563665 115.905792) (xy 136.569036 115.898627) (xy 136.577901 115.897358)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "F.Cu")
+		(uuid "ef78aedf-64bc-4327-b2b0-7896783f274d")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30021)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 133.225 92.05) (xy 133.225 91.55) (xy 132.570671 91.31903) (xy 131.999 91.8) (xy 132.570671 92.28097)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 132.576975 91.321255) (xy 133.217195 91.547244) (xy 133.223855 91.553229) (xy 133.225 91.558277)
+				(xy 133.225 92.041722) (xy 133.221573 92.049995) (xy 133.217194 92.052755) (xy 132.576978 92.278743)
+				(xy 132.568036 92.278265) (xy 132.565552 92.276663) (xy 132.009641 91.808953) (xy 132.005516 91.801004)
+				(xy 132.00822 91.792468) (xy 132.009641 91.791047) (xy 132.565553 91.323335) (xy 132.574088 91.320632)
+			)
+		)
+	)
+	(zone
+		(net 54)
+		(net_name "Net-(RN1C-R3.2)")
+		(layer "F.Cu")
+		(uuid "f02a1f45-4895-4f8b-8cbf-eb24ea43db85")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30064)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 132.780546 114.103769) (xy 132.603769 114.280546) (xy 133.04706 114.793487) (xy 133.500707 114.475707)
+				(xy 133.25 114.025)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 133.25058 114.028377) (xy 133.254015 114.032218) (xy 133.495579 114.466489) (xy 133.496606 114.475384)
+				(xy 133.492067 114.481759) (xy 133.055714 114.787424) (xy 133.046972 114.789364) (xy 133.04015 114.785491)
+				(xy 132.764464 114.466489) (xy 132.610882 114.288776) (xy 132.608065 114.280276) (xy 132.61146 114.272854)
+				(xy 132.777901 114.106413) (xy 132.784233 114.10315) (xy 133.241856 114.026366)
+			)
+		)
+	)
+	(zone
+		(net 10)
+		(net_name "Net-(U3-BYP)")
+		(layer "F.Cu")
+		(uuid "f1b1bffd-f99d-40ff-bfcf-4b7aea4de68c")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30108)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 141.7 105.4875) (xy 141.7 105.7375) (xy 142 105.9125) (xy 142.301 105.6125) (xy 142 105.3125)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 142.006376 105.318855) (xy 142.292685 105.604213) (xy 142.296126 105.612481) (xy 142.292713 105.620759)
+				(xy 142.292685 105.620787) (xy 142.006376 105.906144) (xy 141.998098 105.909557) (xy 141.992222 105.907963)
+				(xy 141.705805 105.740886) (xy 141.700385 105.733758) (xy 141.7 105.73078) (xy 141.7 105.494219)
+				(xy 141.703427 105.485946) (xy 141.7058 105.484116) (xy 141.992224 105.317035) (xy 142.001095 105.315827)
+			)
+		)
+	)
+	(zone
+		(net 14)
+		(net_name "Relay-")
+		(layer "F.Cu")
+		(uuid "f6b1cd79-2529-4137-893a-b5f6cc30502a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30120)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 116.95 94.175) (xy 116.95 93.925) (xy 116.71754 93.825) (xy 116.499 94.05) (xy 116.71754 94.275)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 116.724941 93.828184) (xy 116.730976 93.83078) (xy 116.942924 93.921956) (xy 116.949169 93.928372)
+				(xy 116.95 93.932703) (xy 116.95 94.167296) (xy 116.946573 94.175569) (xy 116.942923 94.178044)
+				(xy 116.724941 94.271815) (xy 116.715987 94.271936) (xy 116.711925 94.269219) (xy 116.707463 94.264625)
+				(xy 116.506916 94.05815) (xy 116.503611 94.04983) (xy 116.506916 94.041849) (xy 116.711926 93.830779)
+				(xy 116.720148 93.827233)
+			)
+		)
+	)
+	(zone
+		(net 9)
+		(net_name "Net-(U2-BYP)")
+		(layer "F.Cu")
+		(uuid "f81661ba-ae90-4a69-9244-d553cbf65e89")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30086)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 138.409099 93.967677) (xy 138.232323 93.790901) (xy 137.957403 93.661418) (xy 137.386793 93.950707)
+				(xy 138.007361 94.204127)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 137.96257 93.663851) (xy 137.962894 93.664004) (xy 138.230478 93.790032) (xy 138.233766 93.792344)
+				(xy 138.39841 93.956988) (xy 138.401837 93.965261) (xy 138.39841 93.973534) (xy 138.396072 93.975344)
+				(xy 138.012355 94.201187) (xy 138.003487 94.20243) (xy 138.001997 94.201936) (xy 137.410507 93.960391)
+				(xy 137.404143 93.95409) (xy 137.404098 93.945136) (xy 137.409638 93.939124) (xy 137.952302 93.664003)
+				(xy 137.961229 93.663319)
+			)
+		)
+	)
+	(zone
+		(net 2)
+		(net_name "Net-(J2-+5V)")
+		(layer "F.Cu")
+		(uuid "fbe4606b-c73e-4b1e-8584-580406c19a1d")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30056)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 125.274112 95.449112) (xy 125.450888 95.625888) (xy 125.840901 95.909099) (xy 126.225707 95.499293)
+				(xy 125.880996 95.064109)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 125.887537 95.072367) (xy 126.219438 95.491378) (xy 126.221889 95.499991) (xy 126.218796 95.506652)
+				(xy 125.84796 95.901581) (xy 125.839799 95.905266) (xy 125.832556 95.903039) (xy 125.451632 95.626428)
+				(xy 125.450234 95.625234) (xy 125.28444 95.45944) (xy 125.281013 95.451167) (xy 125.28444 95.442894)
+				(xy 125.286438 95.441291) (xy 125.872099 95.069752) (xy 125.880921 95.068215)
+			)
+		)
+	)
+	(zone
+		(net 35)
+		(net_name "+5V")
+		(layer "F.Cu")
+		(uuid "fc948c8b-3cb4-4c0b-9f11-e66fee44a9d9")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30043)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 138.501257 91.921967) (xy 138.678033 92.098743) (xy 139.163896 92.407873) (xy 139.500707 91.974293)
+				(xy 139.163896 91.542127)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 139.170136 91.550134) (xy 139.49511 91.967112) (xy 139.497493 91.975744) (xy 139.495122 91.981482)
+				(xy 139.170429 92.399461) (xy 139.162647 92.403892) (xy 139.154908 92.402154) (xy 138.679116 92.099432)
+				(xy 138.677124 92.097834) (xy 138.512073 91.932783) (xy 138.508646 91.92451) (xy 138.512073 91.916237)
+				(xy 138.51452 91.914364) (xy 139.155089 91.547174) (xy 139.163971 91.546034)
+			)
+		)
+	)
+	(zone
+		(net 10)
+		(net_name "Net-(U3-BYP)")
+		(layer "F.Cu")
+		(uuid "ff313d82-ee43-4a56-b56d-a1b8cb847c2a")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30046)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 141.484099 105.992677) (xy 141.307323 105.815901) (xy 140.836104 105.542127) (xy 140.499293 105.975707)
+				(xy 140.848972 106.399274)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 140.844947 105.547265) (xy 140.850006 105.550204) (xy 141.306009 105.815137) (xy 141.308402 105.81698)
+				(xy 141.473814 105.982392) (xy 141.477241 105.990665) (xy 141.473814 105.998938) (xy 141.471849 106.000519)
+				(xy 140.857703 106.393684) (xy 140.848888 106.395258) (xy 140.842372 106.391279) (xy 140.70408 106.223766)
+				(xy 140.505257 105.982932) (xy 140.502634 105.974371) (xy 140.505039 105.968309) (xy 140.82983 105.550203)
+				(xy 140.837611 105.545773)
+			)
+		)
+	)
+	(zone
+		(net 41)
+		(net_name "Curr_Mod")
+		(layer "F.Cu")
+		(uuid "ff591e0b-87d9-4c1c-98fd-3c1f955096fe")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30088)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 121.318683 113.391907) (xy 121.141907 113.568683) (xy 121.4 113.784332) (xy 122.100707 113.750707)
+				(xy 122.134853 113.51)
+			)
+		)
+		(filled_polygon
+			(layer "F.Cu")
+			(pts
+				(xy 121.324478 113.392745) (xy 122.123305 113.508329) (xy 122.131003 113.512905) (xy 122.133214 113.521551)
+				(xy 122.102066 113.741126) (xy 122.097511 113.748836) (xy 122.091043 113.75117) (xy 121.404558 113.784113)
+				(xy 121.396496 113.781404) (xy 121.151725 113.576886) (xy 121.147574 113.568952) (xy 121.150249 113.560406)
+				(xy 121.150943 113.559646) (xy 121.314538 113.396051) (xy 121.32281 113.392625)
 			)
 		)
 	)
@@ -28870,47 +28870,7 @@
 		(net 37)
 		(net_name "+12V")
 		(layer "B.Cu")
-		(uuid "45a4ff95-f914-4934-8a95-1514a26f07dc")
-		(name "$teardrop_padvia$")
-		(hatch none 0.1)
-		(priority 30001)
-		(attr
-			(teardrop
-				(type padvia)
-			)
-		)
-		(connect_pads yes
-			(clearance 0)
-		)
-		(min_thickness 0.0254)
-		(filled_areas_thickness no)
-		(fill yes
-			(thermal_gap 0.5)
-			(thermal_bridge_width 0.5)
-			(island_removal_mode 1)
-			(island_area_min 10)
-		)
-		(polygon
-			(pts
-				(xy 125.480701 93.453924) (xy 125.303924 93.630701) (xy 125.563059 94.129171) (xy 125.813207 93.963207)
-				(xy 125.979171 93.713059)
-			)
-		)
-		(filled_polygon
-			(layer "B.Cu")
-			(pts
-				(xy 125.488305 93.457877) (xy 125.967623 93.707056) (xy 125.973383 93.713912) (xy 125.972607 93.722833)
-				(xy 125.971975 93.723904) (xy 125.814515 93.961234) (xy 125.811234 93.964515) (xy 125.573904 94.121975)
-				(xy 125.565116 94.123694) (xy 125.557687 94.118694) (xy 125.55706 94.117632) (xy 125.307877 93.638306)
-				(xy 125.307102 93.629387) (xy 125.309984 93.62464) (xy 125.474639 93.459985) (xy 125.482911 93.456559)
-			)
-		)
-	)
-	(zone
-		(net 37)
-		(net_name "+12V")
-		(layer "B.Cu")
-		(uuid "801e9225-d2fb-4dd4-85de-50af5516bdb2")
+		(uuid "aa68421f-ef39-4c6c-a6ac-3b67f5ca26b8")
 		(name "$teardrop_padvia$")
 		(hatch none 0.1)
 		(priority 30000)
@@ -28943,6 +28903,46 @@
 				(xy 117.462016 95.589539) (xy 117.456256 95.582682) (xy 117.455949 95.581494) (xy 117.399469 95.302318)
 				(xy 117.399469 95.29768) (xy 117.422554 95.183574) (xy 117.455946 95.018518) (xy 117.460945 95.011092)
 				(xy 117.469733 95.009373)
+			)
+		)
+	)
+	(zone
+		(net 37)
+		(net_name "+12V")
+		(layer "B.Cu")
+		(uuid "dd650509-a965-461e-a6ad-c23104046367")
+		(name "$teardrop_padvia$")
+		(hatch none 0.1)
+		(priority 30001)
+		(attr
+			(teardrop
+				(type padvia)
+			)
+		)
+		(connect_pads yes
+			(clearance 0)
+		)
+		(min_thickness 0.0254)
+		(filled_areas_thickness no)
+		(fill yes
+			(thermal_gap 0.5)
+			(thermal_bridge_width 0.5)
+			(island_removal_mode 1)
+			(island_area_min 10)
+		)
+		(polygon
+			(pts
+				(xy 125.480701 93.453924) (xy 125.303924 93.630701) (xy 125.563059 94.129171) (xy 125.813207 93.963207)
+				(xy 125.979171 93.713059)
+			)
+		)
+		(filled_polygon
+			(layer "B.Cu")
+			(pts
+				(xy 125.488305 93.457877) (xy 125.967623 93.707056) (xy 125.973383 93.713912) (xy 125.972607 93.722833)
+				(xy 125.971975 93.723904) (xy 125.814515 93.961234) (xy 125.811234 93.964515) (xy 125.573904 94.121975)
+				(xy 125.565116 94.123694) (xy 125.557687 94.118694) (xy 125.55706 94.117632) (xy 125.307877 93.638306)
+				(xy 125.307102 93.629387) (xy 125.309984 93.62464) (xy 125.474639 93.459985) (xy 125.482911 93.456559)
 			)
 		)
 	)

--- a/KiCad/LaserBackplane_DVI.kicad_sch
+++ b/KiCad/LaserBackplane_DVI.kicad_sch
@@ -9636,7 +9636,7 @@
 				(hide yes)
 			)
 		)
-		(property "PN" "G6AU-274P-ST-US-DC9"
+		(property "PN" "G6AU-274P-ST-US DC9"
 			(at 134.62 45.72 0)
 			(effects
 				(font


### PR DESCRIPTION
Removed dash before DC9 at the end. The label was `G6AU-274P-ST-US-DC9` and now is `G6AU-274P-ST-US DC9`